### PR TITLE
fix(opensearch-provider): fix working with opensearch 2.x.x

### DIFF
--- a/provider/data_source_opensearch_host.go
+++ b/provider/data_source_opensearch_host.go
@@ -1,13 +1,8 @@
 package provider
 
 import (
-	"errors"
-	"reflect"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
-	elastic7 "github.com/olivere/elastic/v7"
-	elastic6 "gopkg.in/olivere/elastic.v6"
+	"reflect"
 )
 
 func dataSourceOpensearchHost() *schema.Resource {
@@ -36,26 +31,17 @@ func dataSourceOpensearchHostRead(d *schema.ResourceData, m interface{}) error {
 	// it's using. Presumably the URLS would be available where the client is
 	// intantiated, but in terraform, that's not always practicable.
 	var err error
-	esClient, err := getClient(m.(*ProviderConf))
+	client, err := getClient(m.(*ProviderConf))
 	if err != nil {
 		return err
 	}
 
 	var url string
-	switch client := esClient.(type) {
-	case *elastic7.Client:
-		urls := reflect.ValueOf(client).Elem().FieldByName("urls")
-		if urls.Len() > 0 {
-			url = urls.Index(0).String()
-		}
-	case *elastic6.Client:
-		urls := reflect.ValueOf(client).Elem().FieldByName("urls")
-		if urls.Len() > 0 {
-			url = urls.Index(0).String()
-		}
-	default:
-		return errors.New("this version of OpenSearch is not supported")
+	urls := reflect.ValueOf(client).Elem().FieldByName("urls")
+	if urls.Len() > 0 {
+		url = urls.Index(0).String()
 	}
+
 	d.SetId(url)
 	err = d.Set("url", url)
 

--- a/provider/resource_opensearch_component_template.go
+++ b/provider/resource_opensearch_component_template.go
@@ -58,24 +58,20 @@ func resourceOpensearchComponentTemplateRead(d *schema.ResourceData, meta interf
 	var openSearchVersion *version.Version
 
 	providerConf := meta.(*ProviderConf)
-	esClient, err := getClient(providerConf)
+	client, err := getClient(providerConf)
 	if err != nil {
 		return err
 	}
 
-	switch client := esClient.(type) {
-	case *elastic7.Client:
-		openSearchVersion, err = version.NewVersion(providerConf.osVersion)
-		if err == nil {
-			if resourceOpensearchComponentTemplateAvailable(openSearchVersion, providerConf) {
-				result, err = elastic7GetComponentTemplate(client, id)
-			} else {
-				err = fmt.Errorf("component_template endpoint only available from server version >= 7.8, got version %s", openSearchVersion.String())
-			}
+	openSearchVersion, err = version.NewVersion(providerConf.osVersion)
+	if err == nil {
+		if resourceOpensearchComponentTemplateAvailable(openSearchVersion, providerConf) {
+			result, err = elastic7GetComponentTemplate(client, id)
+		} else {
+			err = fmt.Errorf("component_template endpoint only available from server version >= 7.8, got version %s", openSearchVersion.String())
 		}
-	default:
-		err = fmt.Errorf("component_template endpoint only available from server version >= 7.8, got version < 7.0.0")
 	}
+
 	if err != nil {
 		if elastic7.IsNotFound(err) {
 			log.Printf("[WARN] Index template (%s) not found, removing from state", id)
@@ -118,25 +114,19 @@ func resourceOpensearchComponentTemplateDelete(d *schema.ResourceData, meta inte
 	var openSearchVersion *version.Version
 
 	providerConf := meta.(*ProviderConf)
-	esClient, err := getClient(providerConf)
+	client, err := getClient(providerConf)
 	if err != nil {
 		return err
 	}
 
-	switch client := esClient.(type) {
-	case *elastic7.Client:
-		openSearchVersion, err = version.NewVersion(providerConf.osVersion)
-		if err == nil {
-			if resourceOpensearchComponentTemplateAvailable(openSearchVersion, providerConf) {
-				err = elastic7DeleteComponentTemplate(client, id)
-			} else {
-				err = fmt.Errorf("component_template endpoint only available from server version >= 7.8, got version %s", openSearchVersion.String())
-			}
+	openSearchVersion, err = version.NewVersion(providerConf.osVersion)
+	if err == nil {
+		if resourceOpensearchComponentTemplateAvailable(openSearchVersion, providerConf) {
+			err = elastic7DeleteComponentTemplate(client, id)
+		} else {
+			err = fmt.Errorf("component_template endpoint only available from server version >= 7.8, got version %s", openSearchVersion.String())
 		}
-	default:
-		err = fmt.Errorf("component_template endpoint only available from server version >= 7.8, got version < 7.0.0")
 	}
-
 	if err != nil {
 		return err
 	}
@@ -160,23 +150,18 @@ func resourceOpensearchPutComponentTemplate(d *schema.ResourceData, meta interfa
 	var openSearchVersion *version.Version
 
 	providerConf := meta.(*ProviderConf)
-	esClient, err := getClient(providerConf)
+	client, err := getClient(providerConf)
 	if err != nil {
 		return err
 	}
 
-	switch client := esClient.(type) {
-	case *elastic7.Client:
-		openSearchVersion, err = version.NewVersion(providerConf.osVersion)
-		if err == nil {
-			if resourceOpensearchComponentTemplateAvailable(openSearchVersion, providerConf) {
-				err = elastic7PutComponentTemplate(client, name, body, create)
-			} else {
-				err = fmt.Errorf("component_template endpoint only available from server version >= 7.8, got version %s", openSearchVersion.String())
-			}
+	openSearchVersion, err = version.NewVersion(providerConf.osVersion)
+	if err == nil {
+		if resourceOpensearchComponentTemplateAvailable(openSearchVersion, providerConf) {
+			err = elastic7PutComponentTemplate(client, name, body, create)
+		} else {
+			err = fmt.Errorf("component_template endpoint only available from server version >= 7.8, got version %s", openSearchVersion.String())
 		}
-	default:
-		err = fmt.Errorf("component_template endpoint only available from server version >= 7.8, got version < 7.0.0")
 	}
 
 	return err

--- a/provider/resource_opensearch_component_template_test.go
+++ b/provider/resource_opensearch_component_template_test.go
@@ -2,11 +2,8 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
-
-	elastic7 "github.com/olivere/elastic/v7"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -18,26 +15,10 @@ func TestAccOpensearchComponentTemplate(t *testing.T) {
 	if diags.HasError() {
 		t.Skipf("err: %#v", diags)
 	}
-	meta := provider.Meta()
 
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-
-	var allowed bool
-	switch esClient.(type) {
-	case *elastic7.Client:
-		allowed = true
-	default:
-		allowed = false
-	}
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			if !allowed {
-				t.Skip("/_component_template endpoint only supported on ES >= 7.8")
-			}
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckOpensearchComponentTemplateDestroy,
@@ -58,26 +39,10 @@ func TestAccOpensearchComponentTemplate_importBasic(t *testing.T) {
 	if diags.HasError() {
 		t.Skipf("err: %#v", diags)
 	}
-	meta := provider.Meta()
 
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-
-	var allowed bool
-	switch esClient.(type) {
-	case *elastic7.Client:
-		allowed = true
-	default:
-		allowed = false
-	}
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			if !allowed {
-				t.Skip("/_component_template endpoint only supported on ES >= 7.8")
-			}
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckOpensearchComponentTemplateDestroy,
@@ -106,18 +71,12 @@ func testCheckOpensearchComponentTemplateExists(name string) resource.TestCheckF
 
 		meta := testAccProvider.Meta()
 
-		esClient, err := getClient(meta.(*ProviderConf))
+		client, err := getClient(meta.(*ProviderConf))
 		if err != nil {
 			return err
 		}
 
-		switch client := esClient.(type) {
-		case *elastic7.Client:
-			_, err = client.IndexGetComponentTemplate(rs.Primary.ID).Do(context.TODO())
-		default:
-			err = errors.New("/_component_template endpoint only supported on ES >= 7.8")
-		}
-
+		_, err = client.IndexGetComponentTemplate(rs.Primary.ID).Do(context.TODO())
 		if err != nil {
 			return err
 		}
@@ -134,18 +93,12 @@ func testCheckOpensearchComponentTemplateDestroy(s *terraform.State) error {
 
 		meta := testAccProvider.Meta()
 
-		esClient, err := getClient(meta.(*ProviderConf))
+		client, err := getClient(meta.(*ProviderConf))
 		if err != nil {
 			return err
 		}
 
-		switch client := esClient.(type) {
-		case *elastic7.Client:
-			_, err = client.IndexGetComponentTemplate(rs.Primary.ID).Do(context.TODO())
-		default:
-			err = errors.New("/_component_template endpoint only supported on ES >= 7.8")
-		}
-
+		_, err = client.IndexGetComponentTemplate(rs.Primary.ID).Do(context.TODO())
 		if err != nil {
 			return nil // should be not found error
 		}

--- a/provider/resource_opensearch_composable_index_template.go
+++ b/provider/resource_opensearch_composable_index_template.go
@@ -59,24 +59,20 @@ func resourceOpensearchComposableIndexTemplateRead(d *schema.ResourceData, meta 
 	var openSearchVersion *version.Version
 
 	providerConf := meta.(*ProviderConf)
-	esClient, err := getClient(providerConf)
+	client, err := getClient(providerConf)
 	if err != nil {
 		return err
 	}
 
-	switch client := esClient.(type) {
-	case *elastic7.Client:
-		openSearchVersion, err = version.NewVersion(providerConf.osVersion)
-		if err == nil {
-			if resourceOpensearchComposableIndexTemplateAvailable(openSearchVersion, providerConf) {
-				result, err = elastic7GetIndexTemplate(client, id)
-			} else {
-				err = fmt.Errorf("index_template endpoint only available from server version >= 7.8, got version %s", openSearchVersion.String())
-			}
+	openSearchVersion, err = version.NewVersion(providerConf.osVersion)
+	if err == nil {
+		if resourceOpensearchComposableIndexTemplateAvailable(openSearchVersion, providerConf) {
+			result, err = elastic7GetIndexTemplate(client, id)
+		} else {
+			err = fmt.Errorf("index_template endpoint only available from server version >= 7.8, got version %s", openSearchVersion.String())
 		}
-	default:
-		err = fmt.Errorf("index_template endpoint only available from server version >= 7.8, got version < 7.0.0")
 	}
+
 	if err != nil {
 		if elastic7.IsNotFound(err) {
 			log.Printf("[WARN] Index template (%s) not found, removing from state", id)
@@ -120,23 +116,18 @@ func resourceOpensearchComposableIndexTemplateDelete(d *schema.ResourceData, met
 	var openSearchVersion *version.Version
 
 	providerConf := meta.(*ProviderConf)
-	esClient, err := getClient(providerConf)
+	client, err := getClient(providerConf)
 	if err != nil {
 		return err
 	}
 
-	switch client := esClient.(type) {
-	case *elastic7.Client:
-		openSearchVersion, err = version.NewVersion(providerConf.osVersion)
-		if err == nil {
-			if resourceOpensearchComposableIndexTemplateAvailable(openSearchVersion, providerConf) {
-				err = elastic7DeleteIndexTemplate(client, id)
-			} else {
-				err = fmt.Errorf("index_template endpoint only available from server version >= 7.8, got version %s", openSearchVersion.String())
-			}
+	openSearchVersion, err = version.NewVersion(providerConf.osVersion)
+	if err == nil {
+		if resourceOpensearchComposableIndexTemplateAvailable(openSearchVersion, providerConf) {
+			err = elastic7DeleteIndexTemplate(client, id)
+		} else {
+			err = fmt.Errorf("index_template endpoint only available from server version >= 7.8, got version %s", openSearchVersion.String())
 		}
-	default:
-		err = fmt.Errorf("index_template endpoint only available from server version >= 7.8, got version < 7.0.0")
 	}
 
 	if err != nil {
@@ -158,23 +149,18 @@ func resourceOpensearchPutComposableIndexTemplate(d *schema.ResourceData, meta i
 	var openSearchVersion *version.Version
 
 	providerConf := meta.(*ProviderConf)
-	esClient, err := getClient(providerConf)
+	client, err := getClient(providerConf)
 	if err != nil {
 		return err
 	}
 
-	switch client := esClient.(type) {
-	case *elastic7.Client:
-		openSearchVersion, err = version.NewVersion(providerConf.osVersion)
-		if err == nil {
-			if resourceOpensearchComposableIndexTemplateAvailable(openSearchVersion, providerConf) {
-				err = elastic7PutIndexTemplate(client, name, body, create)
-			} else {
-				err = fmt.Errorf("index_template endpoint only available from server version >= 7.8, got version %s", openSearchVersion.String())
-			}
+	openSearchVersion, err = version.NewVersion(providerConf.osVersion)
+	if err == nil {
+		if resourceOpensearchComposableIndexTemplateAvailable(openSearchVersion, providerConf) {
+			err = elastic7PutIndexTemplate(client, name, body, create)
+		} else {
+			err = fmt.Errorf("index_template endpoint only available from server version >= 7.8, got version %s", openSearchVersion.String())
 		}
-	default:
-		err = fmt.Errorf("index_template endpoint only available from server version >= 7.8, got version < 7.0.0")
 	}
 
 	return err

--- a/provider/resource_opensearch_composable_index_template_test.go
+++ b/provider/resource_opensearch_composable_index_template_test.go
@@ -2,11 +2,8 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
-
-	elastic7 "github.com/olivere/elastic/v7"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -18,26 +15,10 @@ func TestAccOpensearchComposableIndexTemplate(t *testing.T) {
 	if diags.HasError() {
 		t.Skipf("err: %#v", diags)
 	}
-	meta := provider.Meta()
 
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-
-	var allowed bool
-	switch esClient.(type) {
-	case *elastic7.Client:
-		allowed = true
-	default:
-		allowed = false
-	}
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			if !allowed {
-				t.Skip("/_index_template endpoint only supported on ES >= 7.8")
-			}
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckOpensearchComposableIndexTemplateDestroy,
@@ -58,26 +39,10 @@ func TestAccOpensearchComposableIndexTemplate_importBasic(t *testing.T) {
 	if diags.HasError() {
 		t.Skipf("err: %#v", diags)
 	}
-	meta := provider.Meta()
 
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-
-	var allowed bool
-	switch esClient.(type) {
-	case *elastic7.Client:
-		allowed = true
-	default:
-		allowed = false
-	}
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			if !allowed {
-				t.Skip("/_index_template endpoint only supported on ES >= 7.8")
-			}
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckOpensearchComposableIndexTemplateDestroy,
@@ -106,17 +71,12 @@ func testCheckOpensearchComposableIndexTemplateExists(name string) resource.Test
 
 		meta := testAccProvider.Meta()
 
-		esClient, err := getClient(meta.(*ProviderConf))
+		client, err := getClient(meta.(*ProviderConf))
 		if err != nil {
 			return err
 		}
 
-		switch client := esClient.(type) {
-		case *elastic7.Client:
-			_, err = client.IndexGetIndexTemplate(rs.Primary.ID).Do(context.TODO())
-		default:
-			err = errors.New("/_index_template endpoint only supported on ES >= 7.8")
-		}
+		_, err = client.IndexGetIndexTemplate(rs.Primary.ID).Do(context.TODO())
 
 		if err != nil {
 			return err
@@ -134,18 +94,12 @@ func testCheckOpensearchComposableIndexTemplateDestroy(s *terraform.State) error
 
 		meta := testAccProvider.Meta()
 
-		esClient, err := getClient(meta.(*ProviderConf))
+		client, err := getClient(meta.(*ProviderConf))
 		if err != nil {
 			return err
 		}
 
-		switch client := esClient.(type) {
-		case *elastic7.Client:
-			_, err = client.IndexGetIndexTemplate(rs.Primary.ID).Do(context.TODO())
-		default:
-			err = errors.New("/_index_template endpoint only supported on ES >= 7.8")
-		}
-
+		_, err = client.IndexGetIndexTemplate(rs.Primary.ID).Do(context.TODO())
 		if err != nil {
 			return nil // should be not found error
 		}

--- a/provider/resource_opensearch_dashboard_tenant_test.go
+++ b/provider/resource_opensearch_dashboard_tenant_test.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	elastic7 "github.com/olivere/elastic/v7"
-	elastic6 "gopkg.in/olivere/elastic.v6"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -19,27 +16,11 @@ func TestAccOpensearchOpenDistroDashboardTenant(t *testing.T) {
 	if diags.HasError() {
 		t.Skipf("err: %#v", diags)
 	}
-	meta := provider.Meta()
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	var allowed bool
-	switch esClient.(type) {
-	case *elastic6.Client:
-		allowed = false
-	default:
-		allowed = true
-	}
-
 	randomName := "test" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			if !allowed {
-				t.Skip("Allowed only for ES >= 7")
-			}
 		},
 		Providers:    testAccOpendistroProviders,
 		CheckDestroy: testAccCheckOpensearchDashboardTenantDestroy,
@@ -84,15 +65,10 @@ func testAccCheckOpensearchDashboardTenantDestroy(s *terraform.State) error {
 		meta := testAccOpendistroProvider.Meta()
 
 		var err error
-		esClient, err := getClient(meta.(*ProviderConf))
 		if err != nil {
 			return err
 		}
-		switch esClient.(type) {
-		case *elastic7.Client:
-			_, err = resourceOpensearchGetOpenDistroDashboardTenant(rs.Primary.ID, meta.(*ProviderConf))
-		default:
-		}
+		_, err = resourceOpensearchGetOpenDistroDashboardTenant(rs.Primary.ID, meta.(*ProviderConf))
 
 		if err != nil {
 			return nil // should be not found error
@@ -113,15 +89,10 @@ func testCheckOpensearchDashboardTenantExists(name string) resource.TestCheckFun
 			meta := testAccOpendistroProvider.Meta()
 
 			var err error
-			esClient, err := getClient(meta.(*ProviderConf))
 			if err != nil {
 				return err
 			}
-			switch esClient.(type) {
-			case *elastic7.Client:
-				_, err = resourceOpensearchGetOpenDistroDashboardTenant(rs.Primary.ID, meta.(*ProviderConf))
-			default:
-			}
+			_, err = resourceOpensearchGetOpenDistroDashboardTenant(rs.Primary.ID, meta.(*ProviderConf))
 
 			if err != nil {
 				return err

--- a/provider/resource_opensearch_data_stream.go
+++ b/provider/resource_opensearch_data_stream.go
@@ -54,24 +54,20 @@ func resourceOpensearchDataStreamRead(d *schema.ResourceData, meta interface{}) 
 	var openSearchVersion *version.Version
 
 	providerConf := meta.(*ProviderConf)
-	esClient, err := getClient(providerConf)
+	client, err := getClient(providerConf)
 	if err != nil {
 		return err
 	}
 
-	switch client := esClient.(type) {
-	case *elastic7.Client:
-		openSearchVersion, err = version.NewVersion(providerConf.osVersion)
-		if err == nil {
-			if resourceOpensearchDataStreamAvailable(openSearchVersion, providerConf) {
-				err = elastic7GetDataStream(client, id)
-			} else {
-				err = fmt.Errorf("_data_stream endpoint only available from server version >= 7.9, got version %s", openSearchVersion.String())
-			}
+	openSearchVersion, err = version.NewVersion(providerConf.osVersion)
+	if err == nil {
+		if resourceOpensearchDataStreamAvailable(openSearchVersion, providerConf) {
+			err = elastic7GetDataStream(client, id)
+		} else {
+			err = fmt.Errorf("_data_stream endpoint only available from server version >= 7.9, got version %s", openSearchVersion.String())
 		}
-	default:
-		err = fmt.Errorf("_data_stream endpoint only available from server version >= 7.9, got version < 7.0.0")
 	}
+
 	if err != nil {
 		if elastic7.IsNotFound(err) {
 			log.Printf("[WARN] data stream (%s) not found, removing from state", id)
@@ -93,23 +89,18 @@ func resourceOpensearchDataStreamDelete(d *schema.ResourceData, meta interface{}
 	var openSearchVersion *version.Version
 
 	providerConf := meta.(*ProviderConf)
-	esClient, err := getClient(providerConf)
+	client, err := getClient(providerConf)
 	if err != nil {
 		return err
 	}
 
-	switch client := esClient.(type) {
-	case *elastic7.Client:
-		openSearchVersion, err = version.NewVersion(providerConf.osVersion)
-		if err == nil {
-			if resourceOpensearchDataStreamAvailable(openSearchVersion, providerConf) {
-				err = elastic7DeleteDataStream(client, id)
-			} else {
-				err = fmt.Errorf("_data_stream endpoint only available from server version >= 7.9, got version %s", openSearchVersion.String())
-			}
+	openSearchVersion, err = version.NewVersion(providerConf.osVersion)
+	if err == nil {
+		if resourceOpensearchDataStreamAvailable(openSearchVersion, providerConf) {
+			err = elastic7DeleteDataStream(client, id)
+		} else {
+			err = fmt.Errorf("_data_stream endpoint only available from server version >= 7.9, got version %s", openSearchVersion.String())
 		}
-	default:
-		err = fmt.Errorf("_data_stream endpoint only available from server version >= 7.9, got version < 7.0.0")
 	}
 
 	if err != nil {
@@ -125,23 +116,18 @@ func resourceOpensearchPutDataStream(d *schema.ResourceData, meta interface{}) e
 	var openSearchVersion *version.Version
 
 	providerConf := meta.(*ProviderConf)
-	esClient, err := getClient(providerConf)
+	client, err := getClient(providerConf)
 	if err != nil {
 		return err
 	}
 
-	switch client := esClient.(type) {
-	case *elastic7.Client:
-		openSearchVersion, err = version.NewVersion(providerConf.osVersion)
-		if err == nil {
-			if resourceOpensearchDataStreamAvailable(openSearchVersion, providerConf) {
-				err = elastic7PutDataStream(client, name)
-			} else {
-				err = fmt.Errorf("_data_stream endpoint only available from server version >= 7.9, got version %s", openSearchVersion.String())
-			}
+	openSearchVersion, err = version.NewVersion(providerConf.osVersion)
+	if err == nil {
+		if resourceOpensearchDataStreamAvailable(openSearchVersion, providerConf) {
+			err = elastic7PutDataStream(client, name)
+		} else {
+			err = fmt.Errorf("_data_stream endpoint only available from server version >= 7.9, got version %s", openSearchVersion.String())
 		}
-	default:
-		err = fmt.Errorf("_data_stream endpoint only available from server version >= 7.9, got version < 7.0.0")
 	}
 
 	return err

--- a/provider/resource_opensearch_destination_test.go
+++ b/provider/resource_opensearch_destination_test.go
@@ -4,9 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	elastic7 "github.com/olivere/elastic/v7"
-	elastic6 "gopkg.in/olivere/elastic.v6"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -81,17 +78,7 @@ func testCheckOpensearchDestinationDestroy(s *terraform.State) error {
 		meta := testAccOpendistroProvider.Meta()
 
 		var err error
-		esClient, err := getClient(meta.(*ProviderConf))
-		if err != nil {
-			return err
-		}
-		switch esClient.(type) {
-		case *elastic7.Client:
-			_, err = resourceOpensearchOpenDistroQueryOrGetDestination(rs.Primary.ID, meta.(*ProviderConf))
-		case *elastic6.Client:
-			_, err = resourceOpensearchOpenDistroQueryOrGetDestination(rs.Primary.ID, meta.(*ProviderConf))
-		default:
-		}
+		_, err = resourceOpensearchOpenDistroQueryOrGetDestination(rs.Primary.ID, meta.(*ProviderConf))
 
 		if err != nil {
 			return nil // should be not found error

--- a/provider/resource_opensearch_index_template.go
+++ b/provider/resource_opensearch_index_template.go
@@ -3,13 +3,11 @@ package provider
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	elastic7 "github.com/olivere/elastic/v7"
-	elastic6 "gopkg.in/olivere/elastic.v6"
 )
 
 func resourceOpensearchIndexTemplate() *schema.Resource {
@@ -51,20 +49,14 @@ func resourceOpensearchIndexTemplateRead(d *schema.ResourceData, meta interface{
 
 	var result string
 	var err error
-	esClient, err := getClient(meta.(*ProviderConf))
+	client, err := getClient(meta.(*ProviderConf))
 	if err != nil {
 		return err
 	}
-	switch client := esClient.(type) {
-	case *elastic7.Client:
-		result, err = elastic7IndexGetTemplate(client, id)
-	case *elastic6.Client:
-		result, err = elastic6IndexGetTemplate(client, id)
-	default:
-		return errors.New("opensearch version not supported")
-	}
+	result, err = elastic7IndexGetTemplate(client, id)
+
 	if err != nil {
-		if elastic7.IsNotFound(err) || elastic6.IsNotFound(err) {
+		if elastic7.IsNotFound(err) {
 			log.Printf("[WARN] Index template (%s) not found, removing from state", id)
 			d.SetId("")
 			return nil
@@ -80,26 +72,12 @@ func resourceOpensearchIndexTemplateRead(d *schema.ResourceData, meta interface{
 }
 
 func elastic7IndexGetTemplate(client *elastic7.Client, id string) (string, error) {
-	res, err := client.IndexGetTemplate(id).Do(context.TODO())
+	res, err := client.IndexGetIndexTemplate(id).Do(context.TODO())
 	if err != nil {
 		return "", err
 	}
 
-	t := res[id]
-	tj, err := json.Marshal(t)
-	if err != nil {
-		return "", err
-	}
-	return string(tj), nil
-}
-
-func elastic6IndexGetTemplate(client *elastic6.Client, id string) (string, error) {
-	res, err := client.IndexGetTemplate(id).Do(context.TODO())
-	if err != nil {
-		return "", err
-	}
-
-	t := res[id]
+	t := res
 	tj, err := json.Marshal(t)
 	if err != nil {
 		return "", err
@@ -114,19 +92,14 @@ func resourceOpensearchIndexTemplateUpdate(d *schema.ResourceData, meta interfac
 func resourceOpensearchIndexTemplateDelete(d *schema.ResourceData, meta interface{}) error {
 	id := d.Id()
 
+	log.Printf("[WARN] Index template (%s) will be delete", id)
+
 	var err error
-	esClient, err := getClient(meta.(*ProviderConf))
+	client, err := getClient(meta.(*ProviderConf))
 	if err != nil {
 		return err
 	}
-	switch client := esClient.(type) {
-	case *elastic7.Client:
-		err = elastic7IndexDeleteTemplate(client, id)
-	case *elastic6.Client:
-		err = elastic6IndexDeleteTemplate(client, id)
-	default:
-		return errors.New("opensearch version not supported")
-	}
+	err = elastic7IndexDeleteTemplate(client, id)
 
 	if err != nil {
 		return err
@@ -136,12 +109,7 @@ func resourceOpensearchIndexTemplateDelete(d *schema.ResourceData, meta interfac
 }
 
 func elastic7IndexDeleteTemplate(client *elastic7.Client, id string) error {
-	_, err := client.IndexDeleteTemplate(id).Do(context.TODO())
-	return err
-}
-
-func elastic6IndexDeleteTemplate(client *elastic6.Client, id string) error {
-	_, err := client.IndexDeleteTemplate(id).Do(context.TODO())
+	_, err := client.IndexDeleteIndexTemplate(id).Do(context.TODO())
 	return err
 }
 
@@ -150,28 +118,17 @@ func resourceOpensearchPutIndexTemplate(d *schema.ResourceData, meta interface{}
 	body := d.Get("body").(string)
 
 	var err error
-	esClient, err := getClient(meta.(*ProviderConf))
+	client, err := getClient(meta.(*ProviderConf))
 	if err != nil {
 		return err
 	}
-	switch client := esClient.(type) {
-	case *elastic7.Client:
-		err = elastic7IndexPutTemplate(client, name, body, create)
-	case *elastic6.Client:
-		err = elastic6IndexPutTemplate(client, name, body, create)
-	default:
-		return errors.New("opensearch version not supported")
-	}
+
+	err = elastic7IndexPutTemplate(client, name, body, create)
 
 	return err
 }
 
 func elastic7IndexPutTemplate(client *elastic7.Client, name string, body string, create bool) error {
-	_, err := client.IndexPutTemplate(name).BodyString(body).Create(create).Do(context.TODO())
-	return err
-}
-
-func elastic6IndexPutTemplate(client *elastic6.Client, name string, body string, create bool) error {
-	_, err := client.IndexPutTemplate(name).BodyString(body).Create(create).Do(context.TODO())
+	_, err := client.IndexPutIndexTemplate(name).BodyString(body).Create(create).Do(context.TODO())
 	return err
 }

--- a/provider/resource_opensearch_index_template_test.go
+++ b/provider/resource_opensearch_index_template_test.go
@@ -2,12 +2,8 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
-
-	elastic7 "github.com/olivere/elastic/v7"
-	elastic6 "gopkg.in/olivere/elastic.v6"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -19,20 +15,7 @@ func TestAccOpensearchIndexTemplate(t *testing.T) {
 	if diags.HasError() {
 		t.Skipf("err: %#v", diags)
 	}
-	meta := provider.Meta()
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	var config string
-	switch esClient.(type) {
-	case *elastic7.Client:
-		config = testAccOpensearchIndexTemplateV7
-	case *elastic6.Client:
-		config = testAccOpensearchIndexTemplateV6
-	default:
-		config = testAccOpensearchIndexTemplateV5
-	}
+	config := testAccOpensearchIndexTemplateV7
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -56,20 +39,7 @@ func TestAccOpensearchIndexTemplate_importBasic(t *testing.T) {
 	if diags.HasError() {
 		t.Skipf("err: %#v", diags)
 	}
-	meta := provider.Meta()
-	var config string
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
-	case *elastic7.Client:
-		config = testAccOpensearchIndexTemplateV7
-	case *elastic6.Client:
-		config = testAccOpensearchIndexTemplateV6
-	default:
-		config = testAccOpensearchIndexTemplateV5
-	}
+	config := testAccOpensearchIndexTemplateV7
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -103,18 +73,12 @@ func testCheckOpensearchIndexTemplateExists(name string) resource.TestCheckFunc 
 		meta := testAccProvider.Meta()
 
 		var err error
-		esClient, err := getClient(meta.(*ProviderConf))
+		client, err := getClient(meta.(*ProviderConf))
 		if err != nil {
 			return err
 		}
-		switch client := esClient.(type) {
-		case *elastic7.Client:
-			_, err = client.IndexGetTemplate(rs.Primary.ID).Do(context.TODO())
-		case *elastic6.Client:
-			_, err = client.IndexGetTemplate(rs.Primary.ID).Do(context.TODO())
-		default:
-			return errors.New("opensearch version not supported")
-		}
+
+		_, err = client.IndexGetIndexTemplate(rs.Primary.ID).Do(context.TODO())
 
 		if err != nil {
 			return err
@@ -133,18 +97,11 @@ func testCheckOpensearchIndexTemplateDestroy(s *terraform.State) error {
 		meta := testAccProvider.Meta()
 
 		var err error
-		esClient, err := getClient(meta.(*ProviderConf))
+		client, err := getClient(meta.(*ProviderConf))
 		if err != nil {
 			return err
 		}
-		switch client := esClient.(type) {
-		case *elastic7.Client:
-			_, err = client.IndexGetTemplate(rs.Primary.ID).Do(context.TODO())
-		case *elastic6.Client:
-			_, err = client.IndexGetTemplate(rs.Primary.ID).Do(context.TODO())
-		default:
-			return errors.New("opensearch version not supported")
-		}
+		_, err = client.IndexGetIndexTemplate(rs.Primary.ID).Do(context.TODO())
 
 		if err != nil {
 			return nil // should be not found error
@@ -156,69 +113,70 @@ func testCheckOpensearchIndexTemplateDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccOpensearchIndexTemplateV5 = `
-resource "opensearch_index_template" "test" {
-  name = "terraform-test"
-  body = <<EOF
-{
-  "template": "te*",
-  "settings": {
-    "index": {
-      "number_of_shards": 1
-    }
-  },
-  "mappings": {
-    "type1": {
-      "_source": {
-        "enabled": false
-      },
-      "properties": {
-        "host_name": {
-          "type": "keyword"
-        },
-        "created_at": {
-          "type": "date",
-          "format": "EEE MMM dd HH:mm:ss Z YYYY"
-        }
-      }
-    }
-  }
-}
-EOF
-}
-`
-
-var testAccOpensearchIndexTemplateV6 = `
-resource "opensearch_index_template" "test" {
-  name = "terraform-test"
-  body = <<EOF
-{
-  "index_patterns": ["te*", "bar*"],
-  "settings": {
-    "index": {
-      "number_of_shards": 1
-    }
-  },
-  "mappings": {
-    "type1": {
-      "_source": {
-        "enabled": false
-      },
-      "properties": {
-        "host_name": {
-          "type": "keyword"
-        },
-        "created_at": {
-          "type": "date",
-          "format": "EEE MMM dd HH:mm:ss Z YYYY"
-        }
-      }
-    }
-  }
-}
-EOF
-}
-`
+//
+//var testAccOpensearchIndexTemplateV5 = `
+//resource "opensearch_index_template" "test" {
+//  name = "terraform-test"
+//  body = <<EOF
+//{
+//  "template": "te*",
+//  "settings": {
+//    "index": {
+//      "number_of_shards": 1
+//    }
+//  },
+//  "mappings": {
+//    "type1": {
+//      "_source": {
+//        "enabled": false
+//      },
+//      "properties": {
+//        "host_name": {
+//          "type": "keyword"
+//        },
+//        "created_at": {
+//          "type": "date",
+//          "format": "EEE MMM dd HH:mm:ss Z YYYY"
+//        }
+//      }
+//    }
+//  }
+//}
+//EOF
+//}
+//`
+//
+//var testAccOpensearchIndexTemplateV6 = `
+//resource "opensearch_index_template" "test" {
+//  name = "terraform-test"
+//  body = <<EOF
+//{
+//  "index_patterns": ["te*", "bar*"],
+//  "settings": {
+//    "index": {
+//      "number_of_shards": 1
+//    }
+//  },
+//  "mappings": {
+//    "type1": {
+//      "_source": {
+//        "enabled": false
+//      },
+//      "properties": {
+//        "host_name": {
+//          "type": "keyword"
+//        },
+//        "created_at": {
+//          "type": "date",
+//          "format": "EEE MMM dd HH:mm:ss Z YYYY"
+//        }
+//      }
+//    }
+//  }
+//}
+//EOF
+//}
+//`
 
 var testAccOpensearchIndexTemplateV7 = `
 resource "opensearch_index_template" "test" {

--- a/provider/resource_opensearch_ingest_pipeline_test.go
+++ b/provider/resource_opensearch_ingest_pipeline_test.go
@@ -2,12 +2,8 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
-
-	elastic7 "github.com/olivere/elastic/v7"
-	elastic6 "gopkg.in/olivere/elastic.v6"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -19,21 +15,8 @@ func TestAccOpensearchIngestPipeline(t *testing.T) {
 	if diags.HasError() {
 		t.Skipf("err: %#v", diags)
 	}
-	meta := provider.Meta()
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	var config string
+	config := testAccOpensearchIngestPipelineV7
 
-	switch esClient.(type) {
-	case *elastic7.Client:
-		config = testAccOpensearchIngestPipelineV7
-	case *elastic6.Client:
-		config = testAccOpensearchIngestPipelineV6
-	default:
-		config = testAccOpensearchIngestPipelineV5
-	}
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -57,20 +40,8 @@ func TestAccOpensearchIngestPipeline_importBasic(t *testing.T) {
 	if diags.HasError() {
 		t.Skipf("err: %#v", diags)
 	}
-	meta := provider.Meta()
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	var config string
-	switch esClient.(type) {
-	case *elastic7.Client:
-		config = testAccOpensearchIngestPipelineV7
-	case *elastic6.Client:
-		config = testAccOpensearchIngestPipelineV6
-	default:
-		config = testAccOpensearchIngestPipelineV5
-	}
+
+	config := testAccOpensearchIngestPipelineV7
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -104,18 +75,11 @@ func testCheckOpensearchIngestPipelineExists(name string) resource.TestCheckFunc
 		meta := testAccProvider.Meta()
 
 		var err error
-		esClient, err := getClient(meta.(*ProviderConf))
+		client, err := getClient(meta.(*ProviderConf))
 		if err != nil {
 			return err
 		}
-		switch client := esClient.(type) {
-		case *elastic7.Client:
-			_, err = client.IngestGetPipeline(rs.Primary.ID).Do(context.TODO())
-		case *elastic6.Client:
-			_, err = client.IngestGetPipeline(rs.Primary.ID).Do(context.TODO())
-		default:
-			return errors.New("opensearch version not supported")
-		}
+		_, err = client.IngestGetPipeline(rs.Primary.ID).Do(context.TODO())
 
 		if err != nil {
 			return err
@@ -134,18 +98,11 @@ func testCheckOpensearchIngestPipelineDestroy(s *terraform.State) error {
 		meta := testAccProvider.Meta()
 
 		var err error
-		esClient, err := getClient(meta.(*ProviderConf))
+		client, err := getClient(meta.(*ProviderConf))
 		if err != nil {
 			return err
 		}
-		switch client := esClient.(type) {
-		case *elastic7.Client:
-			_, err = client.IngestGetPipeline(rs.Primary.ID).Do(context.TODO())
-		case *elastic6.Client:
-			_, err = client.IngestGetPipeline(rs.Primary.ID).Do(context.TODO())
-		default:
-			return errors.New("opensearch version not supported")
-		}
+		_, err = client.IngestGetPipeline(rs.Primary.ID).Do(context.TODO())
 
 		if err != nil {
 			return nil // should be not found error
@@ -157,44 +114,44 @@ func testCheckOpensearchIngestPipelineDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccOpensearchIngestPipelineV5 = `
-resource "opensearch_ingest_pipeline" "test" {
-  name = "terraform-test"
-  body = <<EOF
-{
-  "description" : "describe pipeline",
-  "processors" : [
-    {
-      "set" : {
-        "field": "foo",
-        "value": "bar"
-      }
-    }
-  ]
-}
-EOF
-}
-`
+//var testAccOpensearchIngestPipelineV5 = `
+//resource "opensearch_ingest_pipeline" "test" {
+//  name = "terraform-test"
+//  body = <<EOF
+//{
+//  "description" : "describe pipeline",
+//  "processors" : [
+//    {
+//      "set" : {
+//        "field": "foo",
+//        "value": "bar"
+//      }
+//    }
+//  ]
+//}
+//EOF
+//}
+//`
 
-var testAccOpensearchIngestPipelineV6 = `
-resource "opensearch_ingest_pipeline" "test" {
-  name = "terraform-test"
-  body = <<EOF
-{
-  "description" : "describe pipeline",
-  "version": 123,
-  "processors" : [
-    {
-      "set" : {
-        "field": "foo",
-        "value": "bar"
-      }
-    }
-  ]
-}
-EOF
-}
-`
+//var testAccOpensearchIngestPipelineV6 = `
+//resource "opensearch_ingest_pipeline" "test" {
+//  name = "terraform-test"
+//  body = <<EOF
+//{
+//  "description" : "describe pipeline",
+//  "version": 123,
+//  "processors" : [
+//    {
+//      "set" : {
+//        "field": "foo",
+//        "value": "bar"
+//      }
+//    }
+//  ]
+//}
+//EOF
+//}
+//`
 
 var testAccOpensearchIngestPipelineV7 = `
 resource "opensearch_ingest_pipeline" "test" {

--- a/provider/resource_opensearch_ism_policy_mapping.go
+++ b/provider/resource_opensearch_ism_policy_mapping.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -230,25 +229,20 @@ func resourceOpensearchPostOpendistroPolicyMapping(d *schema.ResourceData, m int
 	}
 
 	var body *json.RawMessage
-	esClient, err := getClient(m.(*ProviderConf))
+	client, err := getClient(m.(*ProviderConf))
 	if err != nil {
 		return nil, err
 	}
-	switch client := esClient.(type) {
-	case *elastic7.Client:
-		var res *elastic7.Response
-		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
-			Method: "POST",
-			Path:   path,
-			Body:   requestBody,
-		})
-		if err != nil {
-			return response, fmt.Errorf("error posting policy attachment: %+v : %+v : %+v", path, requestBody, err)
-		}
-		body = &res.Body
-	default:
-		err = errors.New("policy resource not implemented prior to v7")
+	var res *elastic7.Response
+	res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
+		Method: "POST",
+		Path:   path,
+		Body:   requestBody,
+	})
+	if err != nil {
+		return response, fmt.Errorf("error posting policy attachment: %+v : %+v : %+v", path, requestBody, err)
 	}
+	body = &res.Body
 
 	if err != nil {
 		return response, fmt.Errorf("error creating policy mapping: %+v", err)
@@ -271,24 +265,20 @@ func resourceOpensearchGetOpendistroPolicyMapping(indexPattern string, m interfa
 	}
 
 	var body *json.RawMessage
-	esClient, err := getClient(m.(*ProviderConf))
+	client, err := getClient(m.(*ProviderConf))
 	if err != nil {
 		return nil, err
 	}
-	switch client := esClient.(type) {
-	case *elastic7.Client:
-		var res *elastic7.Response
-		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
-			Method: "GET",
-			Path:   path,
-		})
-		if err != nil {
-			return *response, fmt.Errorf("error getting policy attachment: %+v, %w", path, err)
-		}
-		body = &res.Body
-	default:
-		err = errors.New("policy mapping resource not implemented prior to v7")
+
+	var res *elastic7.Response
+	res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
+		Method: "GET",
+		Path:   path,
+	})
+	if err != nil {
+		return *response, fmt.Errorf("error getting policy attachment: %+v, %w", path, err)
 	}
+	body = &res.Body
 
 	if err != nil {
 		return *response, fmt.Errorf("error creating policy mapping: %+v", err)

--- a/provider/resource_opensearch_ism_policy_mapping_test.go
+++ b/provider/resource_opensearch_ism_policy_mapping_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	elastic7 "github.com/olivere/elastic/v7"
-	elastic6 "gopkg.in/olivere/elastic.v6"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -19,27 +18,11 @@ func TestAccOpensearchOpenDistroISMPolicyMapping(t *testing.T) {
 	if diags.HasError() {
 		t.Skipf("err: %#v", diags)
 	}
-	meta := provider.Meta()
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	var allowed bool
-
-	switch esClient.(type) {
-	case *elastic6.Client:
-		allowed = false
-	default:
-		allowed = true
-	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			// TODO add check for OpenDistro <= 1.13
-			if !allowed {
-				t.Skip("OpenDistroISMPolicies only supported on ES 7.")
-			}
 		},
 		Providers:    testAccOpendistroProviders,
 		CheckDestroy: testCheckOpensearchISMPolicyMappingDestroy,
@@ -96,15 +79,10 @@ func indicesMappedToPolicy(policy string) ([]string, error) {
 	var err error
 	var indices map[string]interface{}
 	mappedIndices := []string{}
-	esClient, err := getClient(meta.(*ProviderConf))
 	if err != nil {
 		return mappedIndices, err
 	}
-	switch esClient.(type) {
-	case *elastic7.Client:
-		indices, err = resourceOpensearchGetOpendistroPolicyMapping(policy, meta.(*ProviderConf))
-	default:
-	}
+	indices, err = resourceOpensearchGetOpendistroPolicyMapping(policy, meta.(*ProviderConf))
 
 	if err != nil {
 		return mappedIndices, err

--- a/provider/resource_opensearch_ism_policy_test.go
+++ b/provider/resource_opensearch_ism_policy_test.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	elastic7 "github.com/olivere/elastic/v7"
-	elastic6 "gopkg.in/olivere/elastic.v6"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -18,29 +15,12 @@ func TestAccOpensearchOpenDistroISMPolicy(t *testing.T) {
 	if diags.HasError() {
 		t.Skipf("err: %#v", diags)
 	}
-	meta := provider.Meta()
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	var allowed bool
 
-	var config string
-	switch esClient.(type) {
-	case *elastic6.Client:
-		allowed = true
-		config = testAccOpensearchOpenDistroISMPolicyV6
-	default:
-		allowed = true
-		config = testAccOpensearchOpenDistroISMPolicyV7
-	}
+	config := testAccOpensearchOpenDistroISMPolicyV7
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			if !allowed {
-				t.Skip("OpenDistroISMPolicies only supported on ES 6.")
-			}
 		},
 		Providers:    testAccOpendistroProviders,
 		CheckDestroy: testCheckOpensearchISMPolicyDestroy,
@@ -73,17 +53,7 @@ func testCheckOpensearchISMPolicyExists(name string) resource.TestCheckFunc {
 		meta := testAccOpendistroProvider.Meta()
 
 		var err error
-		esClient, err := getClient(meta.(*ProviderConf))
-		if err != nil {
-			return err
-		}
-		switch esClient.(type) {
-		case *elastic7.Client:
-			_, err = resourceOpensearchGetOpenDistroISMPolicy(rs.Primary.ID, meta.(*ProviderConf))
-		case *elastic6.Client:
-			_, err = resourceOpensearchGetOpenDistroISMPolicy(rs.Primary.ID, meta.(*ProviderConf))
-		default:
-		}
+		_, err = resourceOpensearchGetOpenDistroISMPolicy(rs.Primary.ID, meta.(*ProviderConf))
 
 		if err != nil {
 			return err
@@ -102,17 +72,10 @@ func testCheckOpensearchISMPolicyDestroy(s *terraform.State) error {
 		meta := testAccOpendistroProvider.Meta()
 
 		var err error
-		esClient, err := getClient(meta.(*ProviderConf))
 		if err != nil {
 			return err
 		}
-		switch esClient.(type) {
-		case *elastic7.Client:
-			_, err = resourceOpensearchGetOpenDistroISMPolicy(rs.Primary.ID, meta.(*ProviderConf))
-		case *elastic6.Client:
-			_, err = resourceOpensearchGetOpenDistroISMPolicy(rs.Primary.ID, meta.(*ProviderConf))
-		default:
-		}
+		_, err = resourceOpensearchGetOpenDistroISMPolicy(rs.Primary.ID, meta.(*ProviderConf))
 
 		if err != nil {
 			return nil // should be not found error
@@ -124,60 +87,60 @@ func testCheckOpensearchISMPolicyDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccOpensearchOpenDistroISMPolicyV6 = `
-resource "opensearch_ism_policy" "test_policy" {
-  policy_id = "test_policy"
-  body      = <<EOF
-  {
-		"policy": {
-		  "description": "ingesting logs",
-		  "default_state": "ingest",
-		  "error_notification": {
-        "destination": {
-          "slack": {
-            "url": "https://webhook.slack.example.com"
-          }
-        },
-        "message_template": {
-          "lang": "mustache",
-          "source": "The index *{{ctx.index}}* failed to rollover."
-        }
-      },
-		  "states": [
-				{
-				  "name": "ingest",
-				  "actions": [{
-					  "rollover": {
-						"min_doc_count": 5
-					  }
-					}],
-				  "transitions": [{
-					  "state_name": "search"
-					}]
-				},
-				{
-				  "name": "search",
-				  "actions": [],
-				  "transitions": [{
-					  "state_name": "delete",
-					  "conditions": {
-						"min_index_age": "5m"
-					  }
-					}]
-				},
-				{
-				  "name": "delete",
-				  "actions": [{
-					  "delete": {}
-					}],
-				  "transitions": []
-				}
-			]
-		}
-	}
-  EOF
-}
-`
+//var testAccOpensearchOpenDistroISMPolicyV6 = `
+//resource "opensearch_ism_policy" "test_policy" {
+//  policy_id = "test_policy"
+//  body      = <<EOF
+//  {
+//		"policy": {
+//		  "description": "ingesting logs",
+//		  "default_state": "ingest",
+//		  "error_notification": {
+//        "destination": {
+//          "slack": {
+//            "url": "https://webhook.slack.example.com"
+//          }
+//        },
+//        "message_template": {
+//          "lang": "mustache",
+//          "source": "The index *{{ctx.index}}* failed to rollover."
+//        }
+//      },
+//		  "states": [
+//				{
+//				  "name": "ingest",
+//				  "actions": [{
+//					  "rollover": {
+//						"min_doc_count": 5
+//					  }
+//					}],
+//				  "transitions": [{
+//					  "state_name": "search"
+//					}]
+//				},
+//				{
+//				  "name": "search",
+//				  "actions": [],
+//				  "transitions": [{
+//					  "state_name": "delete",
+//					  "conditions": {
+//						"min_index_age": "5m"
+//					  }
+//					}]
+//				},
+//				{
+//				  "name": "delete",
+//				  "actions": [{
+//					  "delete": {}
+//					}],
+//				  "transitions": []
+//				}
+//			]
+//		}
+//	}
+//  EOF
+//}
+//`
 
 var testAccOpensearchOpenDistroISMPolicyV7 = `
 resource "opensearch_ism_policy" "test_policy" {

--- a/provider/resource_opensearch_monitor.go
+++ b/provider/resource_opensearch_monitor.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 
@@ -13,7 +12,6 @@ import (
 	"github.com/olivere/elastic/uritemplates"
 
 	elastic7 "github.com/olivere/elastic/v7"
-	elastic6 "gopkg.in/olivere/elastic.v6"
 )
 
 var openDistroMonitorSchema = map[string]*schema.Schema{
@@ -62,7 +60,7 @@ func resourceOpensearchOpenDistroMonitorCreate(d *schema.ResourceData, m interfa
 func resourceOpensearchOpenDistroMonitorRead(d *schema.ResourceData, m interface{}) error {
 	res, err := resourceOpensearchOpenDistroGetMonitor(d.Id(), m)
 
-	if elastic6.IsNotFound(err) || elastic7.IsNotFound(err) {
+	if elastic7.IsNotFound(err) {
 		log.Printf("[WARN] Monitor (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
@@ -106,24 +104,14 @@ func resourceOpensearchOpenDistroMonitorDelete(d *schema.ResourceData, m interfa
 		return fmt.Errorf("error building URL path for monitor: %+v", err)
 	}
 
-	esClient, err := getClient(m.(*ProviderConf))
+	client, err := getClient(m.(*ProviderConf))
 	if err != nil {
 		return err
 	}
-	switch client := esClient.(type) {
-	case *elastic7.Client:
-		_, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
-			Method: "DELETE",
-			Path:   path,
-		})
-	case *elastic6.Client:
-		_, err = client.PerformRequest(context.TODO(), elastic6.PerformRequestOptions{
-			Method: "DELETE",
-			Path:   path,
-		})
-	default:
-		err = errors.New("monitor resource not implemented prior to Elastic v6")
-	}
+	_, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
+		Method: "DELETE",
+		Path:   path,
+	})
 
 	return err
 }
@@ -140,34 +128,19 @@ func resourceOpensearchOpenDistroGetMonitor(monitorID string, m interface{}) (*m
 	}
 
 	var body json.RawMessage
-	esClient, err := getClient(m.(*ProviderConf))
+	client, err := getClient(m.(*ProviderConf))
 	if err != nil {
 		return nil, err
 	}
-	switch client := esClient.(type) {
-	case *elastic7.Client:
-		var res *elastic7.Response
-		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
-			Method: "GET",
-			Path:   path,
-		})
-		if err != nil {
-			return response, err
-		}
-		body = res.Body
-	case *elastic6.Client:
-		var res *elastic6.Response
-		res, err = client.PerformRequest(context.TODO(), elastic6.PerformRequestOptions{
-			Method: "GET",
-			Path:   path,
-		})
-		if err != nil {
-			return response, err
-		}
-		body = res.Body
-	default:
-		return response, errors.New("monitor resource not implemented prior to Elastic v6")
+	var res *elastic7.Response
+	res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
+		Method: "GET",
+		Path:   path,
+	})
+	if err != nil {
+		return response, err
 	}
+	body = res.Body
 
 	if err := json.Unmarshal(body, response); err != nil {
 		return response, fmt.Errorf("error unmarshalling monitor body: %+v: %+v", err, body)
@@ -185,36 +158,20 @@ func resourceOpensearchOpenDistroPostMonitor(d *schema.ResourceData, m interface
 	path := "/_opendistro/_alerting/monitors/"
 
 	var body json.RawMessage
-	esClient, err := getClient(m.(*ProviderConf))
+	client, err := getClient(m.(*ProviderConf))
 	if err != nil {
 		return nil, err
 	}
-	switch client := esClient.(type) {
-	case *elastic7.Client:
-		var res *elastic7.Response
-		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
-			Method: "POST",
-			Path:   path,
-			Body:   monitorJSON,
-		})
-		if err != nil {
-			return response, err
-		}
-		body = res.Body
-	case *elastic6.Client:
-		var res *elastic6.Response
-		res, err = client.PerformRequest(context.TODO(), elastic6.PerformRequestOptions{
-			Method: "POST",
-			Path:   path,
-			Body:   monitorJSON,
-		})
-		if err != nil {
-			return response, err
-		}
-		body = res.Body
-	default:
-		return response, errors.New("monitor resource not implemented prior to Elastic v6")
+	var res *elastic7.Response
+	res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
+		Method: "POST",
+		Path:   path,
+		Body:   monitorJSON,
+	})
+	if err != nil {
+		return response, err
 	}
+	body = res.Body
 
 	if err := json.Unmarshal(body, response); err != nil {
 		return response, fmt.Errorf("error unmarshalling monitor body: %+v: %+v", err, body)
@@ -237,36 +194,20 @@ func resourceOpensearchOpenDistroPutMonitor(d *schema.ResourceData, m interface{
 	}
 
 	var body json.RawMessage
-	esClient, err := getClient(m.(*ProviderConf))
+	client, err := getClient(m.(*ProviderConf))
 	if err != nil {
 		return nil, err
 	}
-	switch client := esClient.(type) {
-	case *elastic7.Client:
-		var res *elastic7.Response
-		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
-			Method: "PUT",
-			Path:   path,
-			Body:   monitorJSON,
-		})
-		if err != nil {
-			return response, err
-		}
-		body = res.Body
-	case *elastic6.Client:
-		var res *elastic6.Response
-		res, err = client.PerformRequest(context.TODO(), elastic6.PerformRequestOptions{
-			Method: "PUT",
-			Path:   path,
-			Body:   monitorJSON,
-		})
-		if err != nil {
-			return response, err
-		}
-		body = res.Body
-	default:
-		return response, errors.New("monitor resource not implemented prior to Elastic v6")
+	var res *elastic7.Response
+	res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
+		Method: "PUT",
+		Path:   path,
+		Body:   monitorJSON,
+	})
+	if err != nil {
+		return response, err
 	}
+	body = res.Body
 
 	if err := json.Unmarshal(body, response); err != nil {
 		return response, fmt.Errorf("error unmarshalling monitor body: %+v: %+v", err, body)

--- a/provider/resource_opensearch_monitor_test.go
+++ b/provider/resource_opensearch_monitor_test.go
@@ -4,9 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	elastic7 "github.com/olivere/elastic/v7"
-	elastic6 "gopkg.in/olivere/elastic.v6"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -42,17 +39,10 @@ func testCheckOpensearchMonitorExists(name string) resource.TestCheckFunc {
 		meta := testAccOpendistroProvider.Meta()
 
 		var err error
-		esClient, err := getClient(meta.(*ProviderConf))
 		if err != nil {
 			return err
 		}
-		switch esClient.(type) {
-		case *elastic7.Client:
-			_, err = resourceOpensearchOpenDistroGetMonitor(rs.Primary.ID, meta.(*ProviderConf))
-		case *elastic6.Client:
-			_, err = resourceOpensearchOpenDistroGetMonitor(rs.Primary.ID, meta.(*ProviderConf))
-		default:
-		}
+		_, err = resourceOpensearchOpenDistroGetMonitor(rs.Primary.ID, meta.(*ProviderConf))
 
 		if err != nil {
 			return err
@@ -71,18 +61,10 @@ func testCheckOpensearchMonitorDestroy(s *terraform.State) error {
 		meta := testAccOpendistroProvider.Meta()
 
 		var err error
-		esClient, err := getClient(meta.(*ProviderConf))
 		if err != nil {
 			return err
 		}
-		switch esClient.(type) {
-		case *elastic7.Client:
-			_, err = resourceOpensearchOpenDistroGetMonitor(rs.Primary.ID, meta.(*ProviderConf))
-
-		case *elastic6.Client:
-			_, err = resourceOpensearchOpenDistroGetMonitor(rs.Primary.ID, meta.(*ProviderConf))
-		default:
-		}
+		_, err = resourceOpensearchOpenDistroGetMonitor(rs.Primary.ID, meta.(*ProviderConf))
 
 		if err != nil {
 			return nil // should be not found error

--- a/provider/resource_opensearch_role_test.go
+++ b/provider/resource_opensearch_role_test.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	elastic7 "github.com/olivere/elastic/v7"
-	elastic6 "gopkg.in/olivere/elastic.v6"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -19,27 +16,12 @@ func TestAccOpensearchOpenDistroRole(t *testing.T) {
 	if diags.HasError() {
 		t.Skipf("err: %#v", diags)
 	}
-	meta := provider.Meta()
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	var allowed bool
-	switch esClient.(type) {
-	case *elastic6.Client:
-		allowed = false
-	default:
-		allowed = true
-	}
 
 	randomName := "test" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			if !allowed {
-				t.Skip("Roles only supported on ES >= 7")
-			}
 		},
 		Providers:    testAccOpendistroProviders,
 		CheckDestroy: testAccCheckOpensearchRoleDestroy,
@@ -125,27 +107,12 @@ func TestAccOpensearchOpenDistroRole_importBasic(t *testing.T) {
 	if diags.HasError() {
 		t.Skipf("err: %#v", diags)
 	}
-	meta := provider.Meta()
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	var allowed bool
-	switch esClient.(type) {
-	case *elastic6.Client:
-		allowed = false
-	default:
-		allowed = true
-	}
 
 	randomName := "test" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			if !allowed {
-				t.Skip("Roles only supported on ES >= 7")
-			}
 		},
 		Providers:    testAccOpendistroProviders,
 		CheckDestroy: testAccCheckOpensearchRoleDestroy,
@@ -171,15 +138,10 @@ func testAccCheckOpensearchRoleDestroy(s *terraform.State) error {
 		meta := testAccOpendistroProvider.Meta()
 
 		var err error
-		esClient, err := getClient(meta.(*ProviderConf))
 		if err != nil {
 			return err
 		}
-		switch esClient.(type) {
-		case *elastic7.Client:
-			_, err = resourceOpensearchGetOpenDistroRole(rs.Primary.ID, meta.(*ProviderConf))
-		default:
-		}
+		_, err = resourceOpensearchGetOpenDistroRole(rs.Primary.ID, meta.(*ProviderConf))
 
 		if err != nil {
 			return nil // should be not found error
@@ -200,15 +162,10 @@ func testCheckOpensearchRoleExists(name string) resource.TestCheckFunc {
 			meta := testAccOpendistroProvider.Meta()
 
 			var err error
-			esClient, err := getClient(meta.(*ProviderConf))
 			if err != nil {
 				return err
 			}
-			switch esClient.(type) {
-			case *elastic7.Client:
-				_, err = resourceOpensearchGetOpenDistroRole(rs.Primary.ID, meta.(*ProviderConf))
-			default:
-			}
+			_, err = resourceOpensearchGetOpenDistroRole(rs.Primary.ID, meta.(*ProviderConf))
 
 			if err != nil {
 				return err

--- a/provider/resource_opensearch_roles_mapping_test.go
+++ b/provider/resource_opensearch_roles_mapping_test.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	elastic7 "github.com/olivere/elastic/v7"
-	elastic6 "gopkg.in/olivere/elastic.v6"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -19,27 +16,12 @@ func TestAccOpensearchOpenDistroRolesMapping(t *testing.T) {
 	if diags.HasError() {
 		t.Skipf("err: %#v", diags)
 	}
-	meta := provider.Meta()
-	var allowed bool
-	esClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	switch esClient.(type) {
-	case *elastic6.Client:
-		allowed = false
-	default:
-		allowed = true
-	}
 
 	randomName := "test" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			if !allowed {
-				t.Skip("Roles only supported on ES >= 7")
-			}
 		},
 		Providers:    testAccOpendistroProviders,
 		CheckDestroy: testAccCheckOpensearchRolesMappingDestroy,
@@ -89,16 +71,7 @@ func testAccCheckOpensearchRolesMappingDestroy(s *terraform.State) error {
 		meta := testAccOpendistroProvider.Meta()
 
 		var err error
-		esClient, err := getClient(meta.(*ProviderConf))
-		if err != nil {
-			return err
-		}
-		switch esClient.(type) {
-		case *elastic7.Client:
-			_, err = resourceOpensearchGetOpenDistroRolesMapping(rs.Primary.ID, meta.(*ProviderConf))
-		default:
-		}
-
+		_, err = resourceOpensearchGetOpenDistroRolesMapping(rs.Primary.ID, meta.(*ProviderConf))
 		if err != nil {
 			return nil // should be not found error
 		}
@@ -116,18 +89,8 @@ func testCheckOpensearchRolesMappingExists(name string) resource.TestCheckFunc {
 			}
 
 			meta := testAccOpendistroProvider.Meta()
-
 			var err error
-			esClient, err := getClient(meta.(*ProviderConf))
-			if err != nil {
-				return err
-			}
-			switch esClient.(type) {
-			case *elastic7.Client:
-				_, err = resourceOpensearchGetOpenDistroRolesMapping(rs.Primary.ID, meta.(*ProviderConf))
-			default:
-			}
-
+			_, err = resourceOpensearchGetOpenDistroRolesMapping(rs.Primary.ID, meta.(*ProviderConf))
 			if err != nil {
 				return err
 			}

--- a/provider/resource_opensearch_script_test.go
+++ b/provider/resource_opensearch_script_test.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	elastic7 "github.com/olivere/elastic/v7"
-	elastic6 "gopkg.in/olivere/elastic.v6"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -43,17 +40,11 @@ func testCheckOpensearchScriptExists(name string) resource.TestCheckFunc {
 		meta := testAccProvider.Meta()
 
 		var err error
-		esClient, err := getClient(meta.(*ProviderConf))
+		client, err := getClient(meta.(*ProviderConf))
 		if err != nil {
 			return err
 		}
-		switch client := esClient.(type) {
-		case *elastic7.Client:
-			_, err = client.GetScript().Id("my_script").Do(context.TODO())
-		case *elastic6.Client:
-			_, err = client.GetScript().Id("my_script").Do(context.TODO())
-		default:
-		}
+		_, err = client.GetScript().Id("my_script").Do(context.TODO())
 
 		if err != nil {
 			return err
@@ -72,17 +63,11 @@ func testCheckOpensearchScriptDestroy(s *terraform.State) error {
 		meta := testAccProvider.Meta()
 
 		var err error
-		esClient, err := getClient(meta.(*ProviderConf))
+		client, err := getClient(meta.(*ProviderConf))
 		if err != nil {
 			return err
 		}
-		switch client := esClient.(type) {
-		case *elastic7.Client:
-			_, err = client.GetScript().Id("my_script").Do(context.TODO())
-		case *elastic6.Client:
-			_, err = client.GetScript().Id("my_script").Do(context.TODO())
-		default:
-		}
+		_, err = client.GetScript().Id("my_script").Do(context.TODO())
 
 		if err != nil {
 			return nil // should be not found error

--- a/provider/resource_opensearch_snapshot_repository_test.go
+++ b/provider/resource_opensearch_snapshot_repository_test.go
@@ -2,12 +2,8 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
-
-	elastic7 "github.com/olivere/elastic/v7"
-	elastic6 "gopkg.in/olivere/elastic.v6"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -60,18 +56,11 @@ func testCheckOpensearchSnapshotRepositoryExists(name string) resource.TestCheck
 		meta := testAccProvider.Meta()
 
 		var err error
-		esClient, err := getClient(meta.(*ProviderConf))
+		client, err := getClient(meta.(*ProviderConf))
 		if err != nil {
 			return err
 		}
-		switch client := esClient.(type) {
-		case *elastic7.Client:
-			_, err = client.SnapshotGetRepository(rs.Primary.ID).Do(context.TODO())
-		case *elastic6.Client:
-			_, err = client.SnapshotGetRepository(rs.Primary.ID).Do(context.TODO())
-		default:
-			return errors.New("opensearch version not supported")
-		}
+		_, err = client.SnapshotGetRepository(rs.Primary.ID).Do(context.TODO())
 
 		if err != nil {
 			return err
@@ -90,18 +79,11 @@ func testCheckOpensearchSnapshotRepositoryDestroy(s *terraform.State) error {
 		meta := testAccProvider.Meta()
 
 		var err error
-		esClient, err := getClient(meta.(*ProviderConf))
+		client, err := getClient(meta.(*ProviderConf))
 		if err != nil {
 			return err
 		}
-		switch client := esClient.(type) {
-		case *elastic7.Client:
-			_, err = client.SnapshotGetRepository(rs.Primary.ID).Do(context.TODO())
-		case *elastic6.Client:
-			_, err = client.SnapshotGetRepository(rs.Primary.ID).Do(context.TODO())
-		default:
-			return errors.New("opensearch version not supported")
-		}
+		_, err = client.SnapshotGetRepository(rs.Primary.ID).Do(context.TODO())
 
 		if err != nil {
 			return nil // should be not found error

--- a/provider/resource_opensearch_user.go
+++ b/provider/resource_opensearch_user.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -112,23 +111,18 @@ func resourceOpensearchOpenDistroUserDelete(d *schema.ResourceData, m interface{
 		return fmt.Errorf("Error building URL path for user: %+v", err)
 	}
 
-	esClient, err := getClient(m.(*ProviderConf))
+	client, err := getClient(m.(*ProviderConf))
 	if err != nil {
 		return err
 	}
-	switch client := esClient.(type) {
-	case *elastic7.Client:
-		_, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
-			Method:           "DELETE",
-			Path:             path,
-			RetryStatusCodes: []int{http.StatusConflict, http.StatusInternalServerError},
-			Retrier: elastic7.NewBackoffRetrier(
-				elastic7.NewExponentialBackoff(100*time.Millisecond, 30*time.Second),
-			),
-		})
-	default:
-		err = errors.New("Role resource not implemented prior to v7")
-	}
+	_, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
+		Method:           "DELETE",
+		Path:             path,
+		RetryStatusCodes: []int{http.StatusConflict, http.StatusInternalServerError},
+		Retrier: elastic7.NewBackoffRetrier(
+			elastic7.NewExponentialBackoff(100*time.Millisecond, 30*time.Second),
+		),
+	})
 
 	return err
 }
@@ -146,24 +140,19 @@ func resourceOpensearchGetOpenDistroUser(userID string, m interface{}) (UserBody
 	}
 
 	var body json.RawMessage
-	esClient, err := getClient(m.(*ProviderConf))
+	client, err := getClient(m.(*ProviderConf))
 	if err != nil {
 		return *user, err
 	}
-	switch client := esClient.(type) {
-	case *elastic7.Client:
-		var res *elastic7.Response
-		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
-			Method: "GET",
-			Path:   path,
-		})
-		if err != nil {
-			return *user, err
-		}
-		body = res.Body
-	default:
-		return *user, errors.New("Role resource not implemented prior to v7")
+	var res *elastic7.Response
+	res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
+		Method: "GET",
+		Path:   path,
+	})
+	if err != nil {
+		return *user, err
 	}
+	body = res.Body
 
 	var userDefinition map[string]UserBody
 
@@ -205,42 +194,37 @@ func resourceOpensearchPutOpenDistroUser(d *schema.ResourceData, m interface{}) 
 	}
 
 	var body json.RawMessage
-	esClient, err := getClient(m.(*ProviderConf))
+	client, err := getClient(m.(*ProviderConf))
 	if err != nil {
 		return nil, err
 	}
-	switch client := esClient.(type) {
-	case *elastic7.Client:
-		var res *elastic7.Response
-		log.Printf("[INFO] put opendistro user: %+v", userDefinition)
-		res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
-			Method: "PUT",
-			Path:   path,
-			Body:   string(userJSON),
-			// see https://github.com/opendistro-for-
-			// elasticsearch/security/issues/1095, this should return a 409, but
-			// retry on the 500 as well. We can't parse the message to only retry on
-			// the conlict exception becaues the client doesn't directly
-			// expose the error response body
-			RetryStatusCodes: []int{http.StatusConflict, http.StatusInternalServerError},
-			Retrier: elastic7.NewBackoffRetrier(
-				elastic7.NewExponentialBackoff(100*time.Millisecond, 30*time.Second),
-			),
-		})
-		if err != nil {
-			e, ok := err.(*elastic7.Error)
-			if !ok {
-				log.Printf("[INFO] expected error to be of type *elastic.Error")
-			} else {
-				log.Printf("[INFO] error creating user: %v %v %v", res, res.Body, e)
-			}
-			return response, err
+	var res *elastic7.Response
+	log.Printf("[INFO] put opendistro user: %+v", userDefinition)
+	res, err = client.PerformRequest(context.TODO(), elastic7.PerformRequestOptions{
+		Method: "PUT",
+		Path:   path,
+		Body:   string(userJSON),
+		// see https://github.com/opendistro-for-
+		// elasticsearch/security/issues/1095, this should return a 409, but
+		// retry on the 500 as well. We can't parse the message to only retry on
+		// the conlict exception becaues the client doesn't directly
+		// expose the error response body
+		RetryStatusCodes: []int{http.StatusConflict, http.StatusInternalServerError},
+		Retrier: elastic7.NewBackoffRetrier(
+			elastic7.NewExponentialBackoff(100*time.Millisecond, 30*time.Second),
+		),
+	})
+	if err != nil {
+		e, ok := err.(*elastic7.Error)
+		if !ok {
+			log.Printf("[INFO] expected error to be of type *elastic.Error")
+		} else {
+			log.Printf("[INFO] error creating user: %v %v %v", res, res.Body, e)
 		}
-
-		body = res.Body
-	default:
-		return response, errors.New("User resource not implemented prior to v7")
+		return response, err
 	}
+
+	body = res.Body
 
 	if err := json.Unmarshal(body, response); err != nil {
 		return response, fmt.Errorf("Error unmarshalling user body: %+v: %+v", err, body)

--- a/provider/util.go
+++ b/provider/util.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mitchellh/go-homedir"
 	elastic7 "github.com/olivere/elastic/v7"
-	elastic6 "gopkg.in/olivere/elastic.v6"
 )
 
 var (
@@ -25,23 +24,6 @@ var (
 func elastic7GetObject(client *elastic7.Client, index string, id string) (*elastic7.GetResult, error) {
 	result, err := client.Get().
 		Index(index).
-		Id(id).
-		Do(context.TODO())
-
-	if err != nil {
-		return nil, err
-	}
-	if !result.Found {
-		return nil, errObjNotFound
-	}
-
-	return result, nil
-}
-
-func elastic6GetObject(client *elastic6.Client, objectType string, index string, id string) (*elastic6.GetResult, error) {
-	result, err := client.Get().
-		Index(index).
-		Type(objectType).
 		Id(id).
 		Do(context.TODO())
 


### PR DESCRIPTION
Signed-off-by: serge-r zoneofmail@gmail.com

### Description
Hello!

Some time ago, I tried to use this provider to support our Opensearch 2.4.0 infrastructure in Terraform. But I have found the next problems:

- **version mismatch problem** - Opensearch is using different version numbers, instead of Elasticsearch, but this provider is checking it only for Elastic, which makes this provider not usable for Opensearch.
- **deprecated API for index templates** - _elastic7.client.IndexDeleteTemplate_ and _elastic7.client.IndexGetTemplate_ are deprecated functions and lead to problems during usage, I have changed it to actual versions.
- **elastic6 support** - I'm not sure, that elastic6 lib is actually for Opensearch because Opensearch has been made from Elasticsearch 7 versions. I also didn't find info about API compatibility with Elasticsearch version 6. I have removed the version-checking mechanism in this PR, and it makes elastic6 lib unusable. I preferred to remove elastic6 lib too.

Perhaps there are more problems, but at this time I have tested only Indexes and IndexTemplates resources.

I know also about https://github.com/phillbaker/terraform-provider-elasticsearch, which this provider was forked from, but I think, that is more about Elasticsearch, not Opensearch. Unfortunately, this provider also has the same problems with version detection.

Please say what are you thinking about this PR. And also big thanks for your and Phillbaker's work!

### Issues Resolved

- **version mismatch problem**
- **deprecated API for index templates**


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
