### PR TITLE
Update the `test` workflow to support the release process

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,8 +123,6 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     name: Release
-    env:
-      GITHUB_TOKEN_ENCRYPTED:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -134,14 +132,15 @@ jobs:
         go-version: 1.18.x
     - name: Import GPG key
       id: import_gpg
-      uses: crazy-max/ghaction-import-gpg@v2
-      env:
-        GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+      uses: crazy-max/ghaction-import-gpg@v5
+      with:
+        gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+        passphrase: ${{ secrets.GPG_PASSPHRASE }}
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2.1.1
       with:
         version: latest
         args: release --rm-dist
       env:
-        GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}


### PR DESCRIPTION
### Description
Update the `test` workflow to add `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` 
Update the `test` workflow to use secret manager to fetch the credentials related to GPG

### Issues Resolved
https://github.com/opensearch-project/terraform-provider-opensearch/issues/8

From [goreleaser](https://github.com/goreleaser/goreleaser-action/blob/master/README.md) and [GitHub](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret) documentation, by default a `GITHUB_TOKEN` is generated by the runners that has repo confined access, with that we dont need to create another personal access token.

Using more using secure way to fetch the GPG secrets.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
