### PR TITLE
[dashboard] Fix underlying index name for dashboards

### DIFF
--- a/provider/resource_opensearch_dashboard_object.go
+++ b/provider/resource_opensearch_dashboard_object.go
@@ -70,7 +70,7 @@ func resourceOpensearchDashboardObject() *schema.Resource {
 			"index": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     ".dashboard",
+				Default:     ".kibana",
 				Description: "The name of the index where dashboard data is stored.",
 			},
 		},

--- a/provider/resource_opensearch_dashboard_object_test.go
+++ b/provider/resource_opensearch_dashboard_object_test.go
@@ -137,9 +137,9 @@ func testCheckOpensearchDashboardObjectExists(name string, objectType string, id
 		}
 		switch client := esClient.(type) {
 		case *elastic7.Client:
-			_, err = client.Get().Index(".dashboard").Id(id).Do(context.TODO())
+			_, err = client.Get().Index(".kibana").Id(id).Do(context.TODO())
 		case *elastic6.Client:
-			_, err = client.Get().Index(".dashboard").Type(deprecatedDocType).Id(id).Do(context.TODO())
+			_, err = client.Get().Index(".kibana").Type(deprecatedDocType).Id(id).Do(context.TODO())
 		default:
 			return errors.New("opensearch version not supported")
 		}
@@ -168,9 +168,9 @@ func testCheckOpensearchDashboardObjectDestroy(s *terraform.State) error {
 		}
 		switch client := esClient.(type) {
 		case *elastic7.Client:
-			_, err = client.Get().Index(".dashboard").Id("response-time-percentile").Do(context.TODO())
+			_, err = client.Get().Index(".kibana").Id("response-time-percentile").Do(context.TODO())
 		case *elastic6.Client:
-			_, err = client.Get().Index(".dashboard").Type("visualization").Id("response-time-percentile").Do(context.TODO())
+			_, err = client.Get().Index(".kibana").Type("visualization").Id("response-time-percentile").Do(context.TODO())
 		default:
 			return errors.New("opensearch version not supported")
 		}

--- a/provider/resource_opensearch_dashboard_tenant.go
+++ b/provider/resource_opensearch_dashboard_tenant.go
@@ -105,7 +105,7 @@ func resourceOpensearchOpenDistroDashboardComputeIndex(tenant string) (string, e
 	cleanedTenant := alphanumeric.ReplaceAllString(tenant, "")
 
 	// originalDashboardIndex+"_"+tenant.hashCode()+"_"+tenant.toLowerCase().replaceAll("[^a-z0-9]+", "")
-	return fmt.Sprintf(".dashboard_%v_%v", hashSum, strings.ToLower(cleanedTenant)), nil
+	return fmt.Sprintf(".kibana_%v_%v", hashSum, strings.ToLower(cleanedTenant)), nil
 }
 
 func resourceOpensearchOpenDistroDashboardTenantUpdate(d *schema.ResourceData, m interface{}) error {


### PR DESCRIPTION
### Description
Based on https://github.com/opensearch-project/terraform-provider-opensearch/pull/41, this fixes a bug in 1.x from https://github.com/opensearch-project/terraform-provider-opensearch/pull/17. The internal index name is still .kibana and not .dashboard (as described in opensearch issues, e.g. https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1270).

### Issues Resolved
Misnamed internal index

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
