### PR TITLE
[ci] Test against opensearch 1.2.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,10 +32,10 @@ jobs:
           - "1-opensearch"
         include:
         - os-major-version: "1-opensearch"
-          version: 1.1.0
+          version: 1.2.0
           oss-image: "opensearchproject/opensearch"
-          OS_OPENDISTRO_IMAGE: "opensearchproject/opensearch:1.1.0"
-          OS_DASHBOARD_IMAGE: "opensearchproject/opensearch-dashboards:1.1.0"
+          OS_OPENDISTRO_IMAGE: "opensearchproject/opensearch:1.2.0"
+          OS_DASHBOARD_IMAGE: "opensearchproject/opensearch-dashboards:1.2.0"
           OPENSEARCH_PREFIX: "plugins.security"
           OSS_ENV_VAR: "plugins.security.disabled=true"
     needs: [lint]


### PR DESCRIPTION
### Description
Moves testing support forward to 1.2.x, see https://github.com/opensearch-project/terraform-provider-opensearch/pull/44

### Issues Resolved
Part of 2.x support

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
