### PR TITLE
fix alert normalization

### DIFF
--- a/provider/util.go
+++ b/provider/util.go
@@ -56,7 +56,7 @@ func normalizeMonitor(tpl map[string]interface{}) {
 }
 
 func normalizeMonitorTriggers(triggers []interface{}) {
-	trigger_types := []string{"alerting_trigger", "anomaly_detector_trigger", "bucket_level_trigger", "document_level_trigger", "query_level_trigger"}
+	trigger_types := []string{"alerting_trigger", "anomaly_detector_trigger", "bucket_level_trigger", "chained_alert_trigger", "document_level_trigger", "query_level_trigger"}
 	for _, t := range triggers {
 		if trigger, ok := t.(map[string]interface{}); ok {
 			delete(trigger, "id")

--- a/provider/util.go
+++ b/provider/util.go
@@ -47,6 +47,7 @@ func normalizeMonitor(tpl map[string]interface{}) {
 		normalizeMonitorTriggers(triggers)
 	}
 
+	delete(tpl, "data_sources")
 	delete(tpl, "id")
 	delete(tpl, "last_update_time")
 	delete(tpl, "enabled_time")
@@ -55,14 +56,23 @@ func normalizeMonitor(tpl map[string]interface{}) {
 }
 
 func normalizeMonitorTriggers(triggers []interface{}) {
+	trigger_types := []string{"alerting_trigger", "anomaly_detector_trigger", "bucket_level_trigger", "document_level_trigger", "query_level_trigger"}
 	for _, t := range triggers {
 		if trigger, ok := t.(map[string]interface{}); ok {
 			delete(trigger, "id")
-
-			if actions, ok := trigger["actions"].([]interface{}); ok {
-				normalizeMonitorTriggerActions(actions)
+			for _,trigger_type := range trigger_types {
+				if qlt, ok := trigger[trigger_type].(map[string]interface{}); ok {
+					normalizeMonitorLevelTriggers(qlt)
+				}
 			}
 		}
+	}
+}
+
+func normalizeMonitorLevelTriggers(query_level_trigger map[string]interface{}) {
+	delete(query_level_trigger, "id")
+	if a, ok := query_level_trigger["actions"].([]interface{}); ok {
+		normalizeMonitorTriggerActions(a)
 	}
 }
 

--- a/provider/util.go
+++ b/provider/util.go
@@ -60,7 +60,7 @@ func normalizeMonitorTriggers(triggers []interface{}) {
 	for _, t := range triggers {
 		if trigger, ok := t.(map[string]interface{}); ok {
 			delete(trigger, "id")
-			for _,trigger_type := range trigger_types {
+			for _, trigger_type := range trigger_types {
 				if qlt, ok := trigger[trigger_type].(map[string]interface{}); ok {
 					normalizeMonitorLevelTriggers(qlt)
 				}


### PR DESCRIPTION
### Description
Fix normalization of alerts and triggers. The new API for opensearch rearranged the JSON so we need to update the normalization code.

I took the `trigger_types` from https://github.com/opensearch-project/alerting-dashboards-plugin/blob/353aa258fb9a2f031964427a45da765092c7cf6d/public/pages/CreateTrigger/containers/CreateTrigger/utils/constants.js#L6

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
