### PR TITLE
Allow provider to use the external ID when assuming the role in the p…

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,7 @@ EOF
 
 - `aws_access_key` (String) The access key for use with AWS opensearch Service domains
 - `aws_assume_role_arn` (String) Amazon Resource Name of an IAM Role to assume prior to making AWS API calls.
+- `aws_assume_role_external_id` (Optional) - External ID configured in the role to assume prior to making AWS API calls.
 - `aws_profile` (String) The AWS profile for use with AWS opensearch Service domains
 - `aws_region` (String) The AWS region for use in signing of AWS opensearch requests. Must be specified in order to use AWS URL signing with AWS OpenSearch endpoint exposed on a custom DNS domain.
 - `aws_secret_key` (String) The secret key for use with AWS opensearch Service domains
@@ -115,13 +116,15 @@ provider "opensearch" {
 #### Assume role configuration
 
 You can instruct the provider to assume a role in AWS before interacting with the cluster by setting the `aws_assume_role_arn` variable.
+When necessary, use the aws_assume_role_external_id to pass the extenral ID configured in the policy of the role for the provider to assume the role. 
 
 Example usage:
 
 ```tf
 provider "opensearch" {
-    url                 = "https://search-foo-bar-pqrhr4w3u4dzervg41frow4mmy.us-east-1.es.amazonaws.com"
-    aws_assume_role_arn = "arn:aws:iam::012345678901:role/rolename"
+    url                         = "https://search-foo-bar-pqrhr4w3u4dzervg41frow4mmy.us-east-1.es.amazonaws.com"
+    aws_assume_role_arn         = "arn:aws:iam::012345678901:role/rolename"
+    aws_assume_role_external_id = "SecretID"
 }
 ```
 

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -182,13 +182,15 @@ func TestAWSCredsAssumeRole(t *testing.T) {
 	testRegion := "us-east-1"
 
 	testConfig := map[string]interface{}{
-		"aws_assume_role_arn": "test_arn",
+		"aws_assume_role_arn":         "test_arn",
+		"aws_assume_role_external_id": "secret_id",
 	}
 
 	testConfigData := schema.TestResourceDataRaw(t, Provider().Schema, testConfig)
 
 	conf := &ProviderConf{
-		awsAssumeRoleArn: testConfigData.Get("aws_assume_role_arn").(string),
+		awsAssumeRoleArn:        testConfigData.Get("aws_assume_role_arn").(string),
+		awsAssumeRoleExternalID: testConfigData.Get("aws_assume_role_external_id").(string),
 	}
 	s := awsSession(testRegion, conf)
 	if s == nil {

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -52,13 +52,15 @@ provider "opensearch" {
 #### Assume role configuration
 
 You can instruct the provider to assume a role in AWS before interacting with the cluster by setting the `aws_assume_role_arn` variable.
+When necessary, use the aws_assume_role_external_id to pass the extenral ID configured in the policy of the role for the provider to assume the role. 
 
 Example usage:
 
 ```tf
 provider "opensearch" {
-    url                 = "https://search-foo-bar-pqrhr4w3u4dzervg41frow4mmy.us-east-1.es.amazonaws.com"
-    aws_assume_role_arn = "arn:aws:iam::012345678901:role/rolename"
+    url                         = "https://search-foo-bar-pqrhr4w3u4dzervg41frow4mmy.us-east-1.es.amazonaws.com"
+    aws_assume_role_arn         = "arn:aws:iam::012345678901:role/rolename"
+    aws_assume_role_external_id = "SecretID"
 }
 ```
 


### PR DESCRIPTION
…rovider configuration set up

### Description
The provider needs the external ID configured in the condition of the IAM policy if it's set in the role iam policy when using assume role configuration 


### Issues Resolved
Close issue https://github.com/phillbaker/terraform-provider-elasticsearch/issues/346 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
