### PR TITLE
fix(audit_config): support audit config in 2.x domains/clusters

### DIFF
--- a/provider/resource_opensearch_audit_config.go
+++ b/provider/resource_opensearch_audit_config.go
@@ -199,7 +199,7 @@ func resourceOpensearchAuditConfigCheckVersion(meta interface{}) error {
 		return err
 	}
 
-	if providerConf.flavor != Unknown && openSearchVersion.Segments()[0] != 1 {
+	if providerConf.flavor != Unknown && openSearchVersion.Segments()[0] < 1 {
 		return fmt.Errorf("audit config only available from OpenSearch >= 1.0, got version %s", openSearchVersion.String())
 	}
 

--- a/provider/resource_opensearch_audit_config_test.go
+++ b/provider/resource_opensearch_audit_config_test.go
@@ -8,7 +8,6 @@ import (
 
 	elastic7 "github.com/olivere/elastic/v7"
 
-	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -19,21 +18,10 @@ func TestAccOpensearchOpenSearchSecurityAuditConfig(t *testing.T) {
 	if diags.HasError() {
 		t.Skipf("err: %#v", diags)
 	}
-	meta := provider.Meta()
-	providerConf := meta.(*ProviderConf)
-	var allowed bool
-	version, err := version.NewVersion(providerConf.osVersion)
-	if err != nil {
-		t.Skipf("err: %s", err)
-	}
-	allowed = version.Segments()[0] == 1
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			if !allowed {
-				t.Skip("Audit config only supported on OpenSearch 1.X.Y")
-			}
 		},
 		Providers: testAccOpendistroProviders,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
### Description

Adapted version check for audit config to support 2.x OpenSearch domains/clusters. 

### Issues Resolved

#69 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
