### PR TITLE
Update cluster setting `action_auto_create_index` regex to relax the patterns.

### DIFF
--- a/provider/resource_opensearch_cluster_settings.go
+++ b/provider/resource_opensearch_cluster_settings.go
@@ -263,7 +263,7 @@ func resourceOpensearchClusterSettings() *schema.Resource {
 			"action_auto_create_index": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^(true|false|([-+]?[a-z0-9][a-z0-9_-]*\*?,?)+)$`), "expected value to be one of: true, false or comma-separated list"),
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^(true|false|([-+]?[a-z0-9_*.,]+)+)$`), "expected value to be one of: true, false or comma-separated list"),
 				Description:  "Whether to automatically create an index if it doesn’t already exist and apply any configured index template",
 			},
 			"action_destructive_requires_name": {

--- a/provider/resource_opensearch_cluster_settings_test.go
+++ b/provider/resource_opensearch_cluster_settings_test.go
@@ -85,6 +85,6 @@ func checkOpensearchClusterSettingsDestroy(s *terraform.State) error {
 var testAccOpensearchClusterSettings = `
 resource "opensearch_cluster_settings" "global" {
   cluster_max_shards_per_node = 10
-  action_auto_create_index    = "my-index-000001,index10,-index1*,+ind*"
+  action_auto_create_index    = "my-index-000001,index10,-index1*,+ind*,-.aws_cold_catalog*,+*"
 }
 `


### PR DESCRIPTION
### Description
Update cluster setting `action_auto_create_index` regex to relax the patterns.

### Issues Resolved
https://github.com/opensearch-project/terraform-provider-opensearch/issues/58

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
