### PR TITLE
fix: use provider locally in debug mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func main() {
 
 	if debugMode {
 		//nolint:staticcheck // SA1019 ignore this!
-		err := plugin.Debug(context.Background(), "registry.terraform.io/opensearch-project/terraform-provider-opensearch",
+		err := plugin.Debug(context.Background(), "registry.terraform.io/opensearch-project/opensearch",
 			&plugin.ServeOpts{
 				ProviderFunc: provider.Provider,
 			},


### PR DESCRIPTION
### Description

Allows usage of the provider locally in debug mode

### Issues Resolved

#81

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
