### PR TITLE
added opensearch serverless support

### DIFF
--- a/provider/awsv4.go
+++ b/provider/awsv4.go
@@ -1,0 +1,39 @@
+package provider
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+)
+
+var emptyStringSHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+type awsV4SignerWrapper struct {
+	internal http.RoundTripper
+}
+
+func (client *awsV4SignerWrapper) RoundTrip(request *http.Request) (*http.Response, error) {
+	var hash string
+	if request.Body == nil {
+		hash = emptyStringSHA256
+	} else {
+		payload, error := io.ReadAll(request.Body)
+		request.Body = io.NopCloser(bytes.NewReader(payload))
+		if error != nil {
+			return nil, error
+		}
+		hasher := sha256.New()
+		hasher.Write(payload)
+		hashBytes := hasher.Sum(nil)
+		hash = hex.EncodeToString(hashBytes)
+	}
+	request.Header.Set("X-Amz-Content-Sha256", hash)
+
+	return client.internal.RoundTrip(request)
+}
+
+func Wrap(internal http.RoundTripper) http.RoundTripper {
+	return &awsV4SignerWrapper{internal: internal}
+}

--- a/provider/awsv4_test.go
+++ b/provider/awsv4_test.go
@@ -1,0 +1,57 @@
+package provider
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type MockRoundTripper struct {
+}
+
+func (roundTripper *MockRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	return new(http.Response), nil
+}
+
+func TestRoundTripWithEmptyBody(t *testing.T) {
+	sut := Wrap(new(MockRoundTripper))
+
+	request := new(http.Request)
+	request.Header = make(http.Header)
+
+	_, err := sut.RoundTrip(request)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if header, contains := request.Header["X-Amz-Content-Sha256"]; !contains || len(header) != 1 || header[0] != emptyStringSHA256 {
+		t.Fatal("Request with empty body doesn't contain X-Amz-Content-Sha256 header with empty string hash value.")
+	}
+}
+
+func TestRoundTripWithBody(t *testing.T) {
+	sut := Wrap(new(MockRoundTripper))
+	request := new(http.Request)
+	request.Header = make(http.Header)
+
+	body := "body"
+	request.Body = io.NopCloser(strings.NewReader(body))
+
+	hasher := sha256.New()
+	hasher.Write([]byte(body))
+	hashBytes := hasher.Sum(nil)
+	expectedHash := hex.EncodeToString(hashBytes)
+
+	_, err := sut.RoundTrip(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if header, contains := request.Header["X-Amz-Content-Sha256"]; !contains || len(header) != 1 || header[0] != expectedHash {
+		t.Fatal("Request with body doesn't contain X-Amz-Content-Sha256 header with correct hash value.")
+	}
+}

--- a/provider/awsv4_test.go
+++ b/provider/awsv4_test.go
@@ -28,7 +28,7 @@ func TestRoundTripWithEmptyBody(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if header, contains := request.Header["X-Amz-Content-Sha256"]; !contains || len(header) != 1 || header[0] != emptyStringSHA256 {
+	if header, contains := request.Header["X-Amz-Content-Sha256"]; !contains || len(header) != 1 || header[0] != "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" {
 		t.Fatal("Request with empty body doesn't contain X-Amz-Content-Sha256 header with empty string hash value.")
 	}
 }


### PR DESCRIPTION
### Description
Added Opensearch Serverless support by: 

1. Extending getClient func with configration necessary for working with serverless version. 
2. OSVersion and Flavor values are set explicitly since serverless variant returns empty response on ping request. 
3. Added AWSv4 signing client RoundTripper wrapper to support [required header](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-clients.html#serverless-signing:~:text=delete(index%3A%20index)-,Signing%20HTTP%20requests%20with%20other%20clients,-The%20following%20requirements).  

### Issues Resolved
Closes https://github.com/opensearch-project/terraform-provider-opensearch/issues/90

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
