### PR TITLE
feat(knn_config): support knn config in 2.x indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Examples of resources can be found in the examples directory.
 ./script/install-tools
 export OSS_IMAGE="opensearchproject/opensearch:2"
 docker-compose up -d
-docker-compose ps -a
+docker-compose ps -a  # Checks that the process is running
 export OPENSEARCH_URL=http://admin:admin@localhost:9200
 export TF_LOG=INFO
 TF_ACC=1 go test ./... -v -parallel 20 -cover -short

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -63,6 +63,8 @@ EOF
 - `gc_deletes` (String) The length of time that a deleted document's version number remains available for further versioned operations.
 - `highlight_max_analyzed_offset` (String) The maximum number of characters that will be analyzed for a highlight request. A stringified number.
 - `include_type_name` (String) A string that indicates if and what we should pass to include_type_name parameter. Set to `"false"` when trying to create an index on a v6 cluster without a doc type or set to `"true"` when trying to create an index on a v7 cluster with a doc type. Since mapping updates are not currently supported, this applies only on index create.
+- `index_knn` (Boolean) Indicates whether the index should build native library indices for the knn_vector fields. If set to false, the knn_vector fields will be stored in doc values, but Approximate k-NN search functionality will be disabled.
+- `index_knn_algo_param_ef_search` (String) The size of the dynamic list used during k-NN searches. Higher values lead to more accurate but slower searches. Only available for `nmslib` implementation.
 - `index_similarity_default` (String) A JSON string describing the default index similarity config.
 - `indexing_slowlog_level` (String) Set which logging level to use for the search slow log, can be: `warn`, `info`, `debug`, `trace`
 - `indexing_slowlog_source` (String) Set the number of characters of the `_source` to include in the slowlog lines, `false` or `0` will skip logging the source entirely and setting it to `true` will log the entire source regardless of size. The original `_source` is reformatted by default to make sure that it fits on a single log line.

--- a/provider/resource_opensearch_index_test.go
+++ b/provider/resource_opensearch_index_test.go
@@ -156,6 +156,26 @@ resource "opensearch_index" "test_similarity_config" {
   })
 }
 `
+
+	testAccOpensearchIndexWithKNNConfig = `
+resource "opensearch_index" "test_knn_config" {
+  name               = "terraform-test-update-knn-module"
+  number_of_shards   = 1
+  number_of_replicas = 1
+  index_knn          = true
+}
+`
+
+	testAccOpensearchIndexWithKNNAlgoParamEfSearchConfig = `
+resource "opensearch_index" "test_knn_algo_param_ef_search_config" {
+  name                           = "terraform-test-update-knn-algo-param-ef-search-module"
+  number_of_shards               = 1
+  number_of_replicas             = 1
+  index_knn                      = true
+  index_knn_algo_param_ef_search = 600
+}
+`
+
 	testAccOpensearchIndexRolloverAliasOpendistro = `
 resource opensearch_ism_policy "test" {
   policy_id = "test"
@@ -430,6 +450,38 @@ func TestAccOpensearchIndex_similarityConfig(t *testing.T) {
 				Config: testAccOpensearchIndexWithSimilarityConfig,
 				Check: resource.ComposeTestCheckFunc(
 					checkOpensearchIndexExists("opensearch_index.test_similarity_config"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOpensearchIndex_knnConfig(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: checkOpensearchIndexDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpensearchIndexWithKNNConfig,
+				Check: resource.ComposeTestCheckFunc(
+					checkOpensearchIndexExists("opensearch_index.test_knn_config"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOpensearchIndex_knnAlgoParamEFSearchConfig(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: checkOpensearchIndexDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpensearchIndexWithKNNAlgoParamEfSearchConfig,
+				Check: resource.ComposeTestCheckFunc(
+					checkOpensearchIndexExists("opensearch_index.test_knn_algo_param_ef_search_config"),
 				),
 			},
 		},


### PR DESCRIPTION
### Description
- Adds support for knn configuration in index resource
- Allows for other boolean settings in index resource

It appears from the test suite that other boolean settings such as `load_fixed_bitset_filters_eagerly` would also see issue without this feature. Please review for golang best practices/style as well. Thank you!

### Issues Resolved
Closes: https://github.com/opensearch-project/terraform-provider-opensearch/issues/75

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
