### PR TITLE
Fix error thrown when index configuration has no number_of_replicas specified

### DIFF
--- a/provider/resource_opensearch_index.go
+++ b/provider/resource_opensearch_index.go
@@ -152,6 +152,7 @@ var (
 			Type:        schema.TypeString,
 			Description: "Number of shard replicas. A stringified number.",
 			Optional:    true,
+			Computed:    true,
 		},
 		"auto_expand_replicas": {
 			Type:        schema.TypeString,
@@ -634,8 +635,10 @@ func resourceOpensearchIndexUpdate(d *schema.ResourceData, meta interface{}) err
 	settings := make(map[string]interface{})
 	for _, key := range settingsKeys {
 		schemaName := strings.Replace(key, ".", "_", -1)
-		if d.HasChange(schemaName) {
-			settings[key] = d.Get(schemaName)
+		if _, ok := d.GetOk(schemaName); ok {
+			if d.HasChange(schemaName) {
+				settings[key] = d.Get(schemaName)
+			}
 		}
 	}
 

--- a/provider/resource_opensearch_index_test.go
+++ b/provider/resource_opensearch_index_test.go
@@ -41,6 +41,11 @@ resource "opensearch_index" "test" {
   indexing_slowlog_level                = "warn"
 }
 `
+	testAccOpensearchIndexDefaultShardsReplicas = `
+resource "opensearch_index" "testdefaultshardsreplicas" {
+  name = "terraform-testdefaultshardsreplicas"
+}
+`
 	testAccOpensearchIndexAnalysis = `
 resource "opensearch_index" "test" {
   name               = "terraform-test"
@@ -244,6 +249,28 @@ func TestAccOpensearchIndex(t *testing.T) {
 				Config: testAccOpensearchIndexUpdateForceDestroy,
 				Check: resource.ComposeTestCheckFunc(
 					checkOpensearchIndexUpdated("opensearch_index.test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOpensearchIndexDefaultShardsReplicas(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: checkOpensearchIndexDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpensearchIndexDefaultShardsReplicas,
+				Check: resource.ComposeTestCheckFunc(
+					checkOpensearchIndexExists("opensearch_index.testdefaultshardsreplicas"),
+				),
+			},
+			{
+				Config: testAccOpensearchIndexDefaultShardsReplicas,
+				Check: resource.ComposeTestCheckFunc(
+					checkOpensearchIndexExists("opensearch_index.testdefaultshardsreplicas"),
 				),
 			},
 		},


### PR DESCRIPTION
### Description
Fix error thrown when index configuration has no number_of_replicas specified 

### Issues Resolved
#83 #108

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
