### PR TITLE
fix: Missing cd in README.MD Running test locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ docker-compose up -d
 docker-compose ps -a
 export OPENSEARCH_URL=http://admin:admin@localhost:9200
 export TF_LOG=INFO
+cd ./provider
 TF_ACC=1 go test ./... -v -parallel 20 -cover -short
 ```
 


### PR DESCRIPTION
### Description
```
./script/install-tools
export OSS_IMAGE="opensearchproject/opensearch:2"
docker-compose up -d
docker-compose ps -a
export OPENSEARCH_URL=http://admin:admin@localhost:9200
export TF_LOG=INFO
TF_ACC=1 go test ./... -v -parallel 20 -cover -short
```
In this original script, we run it when current directory is the root of repo. but it doesn't work for the last line of command `go test` because the current directory should be in `provider/`. So I add a line of cd command before the go test command line

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
