### PR TITLE
Remove superfluous variable `flavor`.

### DIFF
--- a/provider/resource_opensearch_audit_config.go
+++ b/provider/resource_opensearch_audit_config.go
@@ -199,7 +199,7 @@ func resourceOpensearchAuditConfigCheckVersion(meta interface{}) error {
 		return err
 	}
 
-	if providerConf.flavor != Unknown && openSearchVersion.Segments()[0] < 1 {
+	if openSearchVersion.Segments()[0] < 1 {
 		return fmt.Errorf("audit config only available from OpenSearch >= 1.0, got version %s", openSearchVersion.String())
 	}
 

--- a/provider/resource_opensearch_component_template.go
+++ b/provider/resource_opensearch_component_template.go
@@ -135,7 +135,7 @@ func resourceOpensearchComponentTemplateDelete(d *schema.ResourceData, meta inte
 }
 
 func resourceOpensearchComponentTemplateAvailable(v *version.Version, c *ProviderConf) bool {
-	return v.GreaterThanOrEqual(osComponentTemplateMinimalVersion) || c.flavor == Unknown
+	return v.GreaterThanOrEqual(osComponentTemplateMinimalVersion)
 }
 
 func elastic7DeleteComponentTemplate(client *elastic7.Client, id string) error {

--- a/provider/resource_opensearch_composable_index_template.go
+++ b/provider/resource_opensearch_composable_index_template.go
@@ -52,7 +52,7 @@ func resourceOpensearchComposableIndexTemplateCreate(d *schema.ResourceData, met
 }
 
 func resourceOpensearchComposableIndexTemplateAvailable(v *version.Version, c *ProviderConf) bool {
-	return v.GreaterThanOrEqual(minimalOSComposableTemplateVersion) || c.flavor == Unknown
+	return v.GreaterThanOrEqual(minimalOSComposableTemplateVersion)
 }
 
 func resourceOpensearchComposableIndexTemplateRead(d *schema.ResourceData, meta interface{}) error {

--- a/provider/resource_opensearch_data_stream.go
+++ b/provider/resource_opensearch_data_stream.go
@@ -45,7 +45,7 @@ func resourceOpensearchDataStreamCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceOpensearchDataStreamAvailable(v *version.Version, c *ProviderConf) bool {
-	return v.GreaterThanOrEqual(minimalOSDataStreamVersion) || c.flavor == Unknown
+	return v.GreaterThanOrEqual(minimalOSDataStreamVersion)
 }
 
 func resourceOpensearchDataStreamRead(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
### Description
The flavor variable inside of the getClient function is currently superfluous. If the value resolves to anything but `opensearch`, the function errors out, and all usages of flavor are after calling the getClient function.

This is especially problematic in combination with the `opensearch_version` provider variable, as setting this value (outside of serverless opensearch), causes the flavor variable to not be resolved, which in turn causes the function to always error out.

NOTE:
I tried running the `tfplugindocs generate` command for the change in description of the tf provider variable, but if I made no mistake, then the master is currently dirty and generates multiple doc changes which have nothing to do with my pull request.
I opted to not commit those changes, as it would muddy the PR.

### Issues Resolved
https://github.com/opensearch-project/terraform-provider-opensearch/issues/36

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
