### PR TITLE
Return error message when healthcheck set to false and credentials are incorrect

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -398,6 +398,8 @@ func getClient(conf *ProviderConf) (*elastic7.Client, error) {
 		info, httpStatus, err := client.Ping(conf.rawUrl).Do(ctx)
 		if httpStatus == http.StatusForbidden {
 			return nil, errors.New("HTTP 403 Forbidden: Permission denied. Please ensure that the correct credentials are being used to access the cluster.")
+		} else if httpStatus == http.StatusUnauthorized {
+			return nil, errors.New("HTTP 401 Unauthorized: Please ensure that the correct credentials are being used to access the cluster")
 		}
 		if err != nil {
 			// Replace the timeout error because it gives no context

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -66,6 +67,29 @@ func TestProvider_impl(t *testing.T) {
 func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("OPENSEARCH_URL"); v == "" {
 		t.Fatal("OPENSEARCH_URL must be set for acceptance tests")
+	}
+}
+
+// Given:
+// 1. invalid username and password and healthcheck is false
+//
+// this tests that 401 error is returned by getClient
+func TestInvalidCredentials(t *testing.T) {
+	parsedUrl, _ := url.Parse("http://127.0.0.1:9200")
+	testConfig := &ProviderConf{
+		username:           "1234",
+		password:           "1234",
+		healthchecking:     false,
+		rawUrl:             "http://127.0.0.1:9200",
+		sniffing:           false,
+		parsedUrl:          parsedUrl,
+		pingTimeoutSeconds: 10,
+	}
+	_, err := getClient(testConfig)
+
+	errString := "HTTP 401 Unauthorized: Please ensure that the correct credentials are being used to access the cluster"
+	if err.Error() != errString {
+		t.Errorf("Error thrown should be %s", errString)
 	}
 }
 


### PR DESCRIPTION
### Description
Return error message when healthcheck is set to false and basic auth credentials provided are incorrect

### Issues Resolved
#115 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
