### PR TITLE
Update Document for index template

### DIFF
--- a/docs/resources/index_template.md
+++ b/docs/resources/index_template.md
@@ -18,22 +18,21 @@ resource "opensearch_index_template" "template_1" {
   name = "template_1"
   body = <<EOF
 {
-  "template": "te*",
-  "settings": {
-    "number_of_shards": 1
-  },
-  "mappings": {
-    "type1": {
-      "_source": {
-        "enabled": false
-      },
+  "index_patterns": [
+    "logs-2020-01-*"
+  ],
+  "template": {
+    "aliases": {
+      "my_logs": {}
+    },
+    "mappings": {
       "properties": {
-        "host_name": {
-          "type": "keyword"
-        },
-        "created_at": {
+        "timestamp": {
           "type": "date",
-          "format": "EEE MMM dd HH:mm:ss Z YYYY"
+          "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
+        },
+        "value": {
+          "type": "double"
         }
       }
     }


### PR DESCRIPTION
### Description
When I use this example codes,  Output 'Bad Requets' messages.
[here](https://github.com/opensearch-project/terraform-provider-opensearch/blob/main/docs/resources/index_template.md)

error message
```
│ Error: elastic: Error 400 (Bad Request): [2:15] [index_template] template doesn't support values of type: VALUE_STRING [type=x_content_parse_exception]
│
│   with module.template.opensearch_index_template.template_1,
│   on ../../modules/template/main.tf line 76, in resource "opensearch_index_template" "template_1":
│   76: resource "opensearch_index_template" "template_1" {
```

It is already fixed [example code](https://github.com/opensearch-project/terraform-provider-opensearch/blob/main/examples/resources/opensearch_index_template/resource.tf)
I execute command `tfplugindocs generate`.  

**Please check this PR** :pray:

### Issues Resolved
N/A


