### PR TITLE
fix example data in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,12 +28,16 @@ resource "opensearch_index_template" "template_1" {
   name = "template_1"
   body = <<EOF
 {
-  "template": "te*",
-  "settings": {
-    "number_of_shards": 1
-  },
-  "mappings": {
-    "type1": {
+  "index_patterns": [
+    "your-pattern-here-*"
+  ],
+  "template": {
+    "settings": {
+      "index": {
+        "number_of_shards": "1"
+      }
+    },
+    "mappings": {
       "_source": {
         "enabled": false
       },

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,22 +72,22 @@ EOF
 - `aws_profile` (String) The AWS profile for use with AWS OpenSearch Service domains
 - `aws_region` (String) The AWS region for use in signing of AWS OpenSearch requests. Must be specified in order to use AWS URL signing with AWS OpenSearch endpoint exposed on a custom DNS domain.
 - `aws_secret_key` (String) The secret key for use with AWS OpenSearch Service domains
-- `aws_signature_service` (String) AWS service name used in the credential scope of signed requests to opensearch.
+- `aws_signature_service` (String) AWS service name used in the credential scope of signed requests to OpenSearch.
 - `aws_token` (String) The session token for use with AWS OpenSearch Service domains
 - `cacert_file` (String) A Custom CA certificate
-- `client_cert_path` (String) A X509 certificate to connect to opensearch
-- `client_key_path` (String) A X509 key to connect to opensearch
-- `healthcheck` (Boolean) Set the client healthcheck option for the opensearch client. Healthchecking is designed for direct access to the cluster.
-- `host_override` (String) If provided, sets the 'Host' header of requests and the 'ServerName' for certificate validation to this value. See the documentation on connecting to opensearch via an SSH tunnel.
+- `client_cert_path` (String) A X509 certificate to connect to OpenSearch
+- `client_key_path` (String) A X509 key to connect to OpenSearch
+- `healthcheck` (Boolean) Set the client healthcheck option for the OpenSearch client. Healthchecking is designed for direct access to the cluster.
+- `host_override` (String) If provided, sets the 'Host' header of requests and the 'ServerName' for certificate validation to this value. See the documentation on connecting to OpenSearch via an SSH tunnel.
 - `insecure` (Boolean) Disable SSL verification of API calls
-- `opensearch_version` (String) opensearch Version
-- `password` (String) Password to use to connect to opensearch using basic auth
-- `proxy` (String) Proxy URL to use for requests to opensearch.
-- `sign_aws_requests` (Boolean) Enable signing of AWS opensearch requests. The `url` must refer to AWS ES domain (`*.<region>.es.amazonaws.com`), or `aws_region` must be specified explicitly.
-- `sniff` (Boolean) Set the node sniffing option for the opensearch client. Client won't work with sniffing if nodes are not routable.
+- `opensearch_version` (String) OpenSearch Version
+- `password` (String) Password to use to connect to OpenSearch using basic auth
+- `proxy` (String) Proxy URL to use for requests to OpenSearch.
+- `sign_aws_requests` (Boolean) Enable signing of AWS OpenSearch requests. The `url` must refer to AWS ES domain (`*.<region>.es.amazonaws.com`), or `aws_region` must be specified explicitly.
+- `sniff` (Boolean) Set the node sniffing option for the OpenSearch client. Client won't work with sniffing if nodes are not routable.
 - `token` (String) A bearer token or ApiKey for an Authorization header, e.g. Active Directory API key.
 - `token_name` (String) The type of token, usually ApiKey or Bearer
-- `username` (String) Username to use to connect to opensearch using basic auth
+- `username` (String) Username to use to connect to OpenSearch using basic auth
 - `version_ping_timeout` (Number) Version ping timeout in seconds
 
 ## Authentication

--- a/docs/resources/component_template.md
+++ b/docs/resources/component_template.md
@@ -20,7 +20,7 @@ resource "opensearch_component_template" "test" {
   "template": {
     "settings": {
       "index": {
-        "number_of_shards": 1
+        "number_of_shards": "1"
       }
     },
     "mappings": {

--- a/docs/resources/composable_index_template.md
+++ b/docs/resources/composable_index_template.md
@@ -21,7 +21,7 @@ resource "opensearch_composable_index_template" "template_1" {
   "template": {
     "settings": {
       "index": {
-        "number_of_shards": 1
+        "number_of_shards": "1"
       }
     },
     "mappings": {

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -21,7 +21,7 @@ resource "opensearch_index" "test-simple-index" {
   mappings           = <<EOF
 {
   "properties": {
-    "email": {
+    "name": {
       "type": "text"
     }
   }
@@ -59,7 +59,7 @@ EOF
 - `highlight_max_analyzed_offset` (String) The maximum number of characters that will be analyzed for a highlight request. A stringified number.
 - `include_type_name` (String) A string that indicates if and what we should pass to include_type_name parameter. Set to `"false"` when trying to create an index on a v6 cluster without a doc type or set to `"true"` when trying to create an index on a v7 cluster with a doc type. Since mapping updates are not currently supported, this applies only on index create.
 - `index_knn` (Boolean) Indicates whether the index should build native library indices for the knn_vector fields. If set to false, the knn_vector fields will be stored in doc values, but Approximate k-NN search functionality will be disabled.
-- `index_knn_algo_param_ef_search` (String) The size of the dynamic list used during k-NN searches. Higher values lead to more accurate but slower searches. Only available for `nmslib` implementation.
+- `index_knn_algo_param_ef_search` (String) The size of the dynamic list used during k-NN searches. Higher values lead to more accurate but slower searches. Only available for nmslib.
 - `index_similarity_default` (String) A JSON string describing the default index similarity config.
 - `indexing_slowlog_level` (String) Set which logging level to use for the search slow log, can be: `warn`, `info`, `debug`, `trace`
 - `indexing_slowlog_source` (String) Set the number of characters of the `_source` to include in the slowlog lines, `false` or `0` will skip logging the source entirely and setting it to `true` will log the entire source regardless of size. The original `_source` is reformatted by default to make sure that it fits on a single log line.

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -14,20 +14,15 @@ Provides an OpenSearch index resource.
 
 ```terraform
 # Create a simple index
-resource "opensearch_index" "test" {
+resource "opensearch_index" "test-simple-index" {
   name               = "terraform-test"
-  number_of_shards   = 1
-  number_of_replicas = 1
+  number_of_shards   = "1"
+  number_of_replicas = "1"
   mappings           = <<EOF
 {
-  "people": {
-    "_all": {
-      "enabled": false
-    },
-    "properties": {
-      "email": {
-        "type": "text"
-      }
+  "properties": {
+    "email": {
+      "type": "text"
     }
   }
 }

--- a/docs/resources/index_template.md
+++ b/docs/resources/index_template.md
@@ -18,12 +18,16 @@ resource "opensearch_index_template" "template_1" {
   name = "template_1"
   body = <<EOF
 {
-  "template": "te*",
-  "settings": {
-    "number_of_shards": 1
-  },
-  "mappings": {
-    "type1": {
+  "index_patterns": [
+    "your-pattern-here-*"
+  ],
+  "template": {
+    "settings": {
+      "index": {
+        "number_of_shards": "1"
+      }
+    },
+    "mappings": {
       "_source": {
         "enabled": false
       },

--- a/docs/resources/index_template.md
+++ b/docs/resources/index_template.md
@@ -19,25 +19,26 @@ resource "opensearch_index_template" "template_1" {
   body = <<EOF
 {
   "index_patterns": [
-    "your-pattern-here-*"
+    "logs-2020-01-*"
   ],
   "template": {
+    "aliases": {
+      "my_logs": {}
+    },
     "settings": {
       "index": {
-        "number_of_shards": "1"
+        "number_of_shards": "2",
+        "number_of_replicas": "1"
       }
     },
     "mappings": {
-      "_source": {
-        "enabled": false
-      },
       "properties": {
-        "host_name": {
-          "type": "keyword"
-        },
-        "created_at": {
+        "timestamp": {
           "type": "date",
-          "format": "EEE MMM dd HH:mm:ss Z YYYY"
+          "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
+        },
+        "value": {
+          "type": "double"
         }
       }
     }

--- a/docs/resources/ism_policy_mapping.md
+++ b/docs/resources/ism_policy_mapping.md
@@ -4,13 +4,14 @@ page_title: "opensearch_ism_policy_mapping Resource - terraform-provider-opensea
 subcategory: ""
 description: |-
   Provides an OpenSearch Index State Management (ISM) policy. Please refer to the OpenSearch ISM documentation for details.
+  !> opensearch_ism_policy_mapping is deprecated in OpenSearch 1.x please use the opensearch_ism_policy resource and specify the ism_template attribute in the policies instead.
 ---
-
-!> **NOTE:** `opensearch_ism_policy_mapping` is deprecated in Opensearch 1.x please use the `opensearch_ism_policy` resource and specify the `ism_template` attribute in the policies instead.
 
 # opensearch_ism_policy_mapping (Resource)
 
 Provides an OpenSearch Index State Management (ISM) policy. Please refer to the OpenSearch ISM documentation for details.
+
+!> `opensearch_ism_policy_mapping` is deprecated in OpenSearch 1.x please use the `opensearch_ism_policy` resource and specify the `ism_template` attribute in the policies instead.
 
 ## Example Usage
 

--- a/docs/resources/ism_policy_mapping.md
+++ b/docs/resources/ism_policy_mapping.md
@@ -6,6 +6,8 @@ description: |-
   Provides an OpenSearch Index State Management (ISM) policy. Please refer to the OpenSearch ISM documentation for details.
 ---
 
+!> **NOTE:** `opensearch_ism_policy_mapping` is deprecated in Opensearch 1.x please use the `opensearch_ism_policy` resource and specify the `ism_template` attribute in the policies instead.
+
 # opensearch_ism_policy_mapping (Resource)
 
 Provides an OpenSearch Index State Management (ISM) policy. Please refer to the OpenSearch ISM documentation for details.

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -8,12 +8,16 @@ resource "opensearch_index_template" "template_1" {
   name = "template_1"
   body = <<EOF
 {
-  "template": "te*",
-  "settings": {
-    "number_of_shards": 1
-  },
-  "mappings": {
-    "type1": {
+  "index_patterns": [
+    "your-pattern-here-*"
+  ],
+  "template": {
+    "settings": {
+      "index": {
+        "number_of_shards": "1"
+      }
+    },
+    "mappings": {
       "_source": {
         "enabled": false
       },

--- a/examples/resources/opensearch_component_template/resource.tf
+++ b/examples/resources/opensearch_component_template/resource.tf
@@ -5,7 +5,7 @@ resource "opensearch_component_template" "test" {
   "template": {
     "settings": {
       "index": {
-        "number_of_shards": 1
+        "number_of_shards": "1"
       }
     },
     "mappings": {

--- a/examples/resources/opensearch_composable_index_template/resource.tf
+++ b/examples/resources/opensearch_composable_index_template/resource.tf
@@ -6,7 +6,7 @@ resource "opensearch_composable_index_template" "template_1" {
   "template": {
     "settings": {
       "index": {
-        "number_of_shards": 1
+        "number_of_shards": "1"
       }
     },
     "mappings": {

--- a/examples/resources/opensearch_index/resource.tf
+++ b/examples/resources/opensearch_index/resource.tf
@@ -1,8 +1,8 @@
 # Create a simple index
-resource "opensearch_index" "test" {
+resource "opensearch_index" "test-simple-index" {
   name               = "terraform-test"
-  number_of_shards   = 1
-  number_of_replicas = 1
+  number_of_shards   = "1"
+  number_of_replicas = "1"
   mappings           = <<EOF
 {
   "properties": {

--- a/examples/resources/opensearch_index_template/resource.tf
+++ b/examples/resources/opensearch_index_template/resource.tf
@@ -10,6 +10,12 @@ resource "opensearch_index_template" "template_1" {
     "aliases": {
       "my_logs": {}
     },
+    "settings": {
+      "index": {
+        "number_of_shards": "2",
+        "number_of_replicas": "1"
+      }
+    },
     "mappings": {
       "properties": {
         "timestamp": {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -30,7 +30,7 @@ import (
 
 type ServerFlavor int64
 
-// opensearch
+// OpenSearch
 const (
 	Unknown ServerFlavor = iota
 	OpenSearch
@@ -78,31 +78,31 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OPENSEARCH_URL", nil),
-				Description: "Opensearch URL",
+				Description: "OpenSearch URL",
 			},
 			"sniff": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OPENSEARCH_SNIFF", false),
-				Description: "Set the node sniffing option for the opensearch client. Client won't work with sniffing if nodes are not routable.",
+				Description: "Set the node sniffing option for the OpenSearch client. Client won't work with sniffing if nodes are not routable.",
 			},
 			"healthcheck": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OPENSEARCH_HEALTH", true),
-				Description: "Set the client healthcheck option for the opensearch client. Healthchecking is designed for direct access to the cluster.",
+				Description: "Set the client healthcheck option for the OpenSearch client. Healthchecking is designed for direct access to the cluster.",
 			},
 			"username": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OPENSEARCH_USERNAME", nil),
-				Description: "Username to use to connect to opensearch using basic auth",
+				Description: "Username to use to connect to OpenSearch using basic auth",
 			},
 			"password": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OPENSEARCH_PASSWORD", nil),
-				Description: "Password to use to connect to opensearch using basic auth",
+				Description: "Password to use to connect to OpenSearch using basic auth",
 			},
 			"token": {
 				Type:        schema.TypeString,
@@ -132,31 +132,31 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "",
-				Description: "The access key for use with AWS opensearch Service domains",
+				Description: "The access key for use with AWS OpenSearch Service domains",
 			},
 			"aws_secret_key": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "",
-				Description: "The secret key for use with AWS opensearch Service domains",
+				Description: "The secret key for use with AWS OpenSearch Service domains",
 			},
 			"aws_token": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "",
-				Description: "The session token for use with AWS opensearch Service domains",
+				Description: "The session token for use with AWS OpenSearch Service domains",
 			},
 			"aws_profile": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "",
-				Description: "The AWS profile for use with AWS opensearch Service domains",
+				Description: "The AWS profile for use with AWS OpenSearch Service domains",
 			},
 			"aws_region": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "",
-				Description: "The AWS region for use in signing of AWS opensearch requests. Must be specified in order to use AWS URL signing with AWS OpenSearch endpoint exposed on a custom DNS domain.",
+				Description: "The AWS region for use in signing of AWS OpenSearch requests. Must be specified in order to use AWS URL signing with AWS OpenSearch endpoint exposed on a custom DNS domain.",
 			},
 			"cacert_file": {
 				Type:        schema.TypeString,
@@ -174,36 +174,36 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "",
-				Description: "A X509 certificate to connect to opensearch",
+				Description: "A X509 certificate to connect to OpenSearch",
 				DefaultFunc: schema.EnvDefaultFunc("OS_CLIENT_CERTIFICATE_PATH", ""),
 			},
 			"client_key_path": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "",
-				Description: "A X509 key to connect to opensearch",
+				Description: "A X509 key to connect to OpenSearch",
 				DefaultFunc: schema.EnvDefaultFunc("OS_CLIENT_KEY_PATH", ""),
 			},
 			"sign_aws_requests": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
-				Description: "Enable signing of AWS opensearch requests. The `url` must refer to AWS ES domain (`*.<region>.es.amazonaws.com`), or `aws_region` must be specified explicitly.",
+				Description: "Enable signing of AWS OpenSearch requests. The `url` must refer to AWS ES domain (`*.<region>.es.amazonaws.com`), or `aws_region` must be specified explicitly.",
 			},
 			"aws_signature_service": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "es",
-				Description: "AWS service name used in the credential scope of signed requests to opensearch.",
+				Description: "AWS service name used in the credential scope of signed requests to OpenSearch.",
 			},
 			"opensearch_version": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "",
-				Description: "opensearch Version",
+				Description: "OpenSearch Version",
 			},
 			// version_ping_timeout is the time the ping to check the cluster
-			// version waits for a response from opensearch on startup, e.g. when
+			// version waits for a response from OpenSearch on startup, e.g. when
 			// creating a provider.
 			"version_ping_timeout": {
 				Type:        schema.TypeInt,
@@ -215,12 +215,12 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "",
-				Description: "If provided, sets the 'Host' header of requests and the 'ServerName' for certificate validation to this value. See the documentation on connecting to opensearch via an SSH tunnel.",
+				Description: "If provided, sets the 'Host' header of requests and the 'ServerName' for certificate validation to this value. See the documentation on connecting to OpenSearch via an SSH tunnel.",
 			},
 			"proxy": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Proxy URL to use for requests to opensearch.",
+				Description: "Proxy URL to use for requests to OpenSearch.",
 			},
 		},
 
@@ -421,7 +421,7 @@ func getClient(conf *ProviderConf) (*elastic7.Client, error) {
 			conf.flavor = OpenSearch
 		}
 	} else if conf.flavor == Unknown || conf.osVersion < "1.0.0" {
-		return nil, fmt.Errorf("opensearch version %s is older than 1.0.0 and is not supported, flavor: %v.", conf.osVersion, conf.flavor)
+		return nil, fmt.Errorf("OpenSearch version %s is older than 1.0.0 and is not supported, flavor: %v.", conf.osVersion, conf.flavor)
 	}
 
 	return client, nil

--- a/provider/resource_opensearch_index_template.go
+++ b/provider/resource_opensearch_index_template.go
@@ -13,7 +13,7 @@ import (
 
 func resourceOpensearchIndexTemplate() *schema.Resource {
 	return &schema.Resource{
-		Description: "Provides an Opensearch index template resource.",
+		Description: "Provides an OpenSearch index template resource.",
 		Create:      resourceOpensearchIndexTemplateCreate,
 		Read:        resourceOpensearchIndexTemplateRead,
 		Update:      resourceOpensearchIndexTemplateUpdate,

--- a/provider/resource_opensearch_ism_policy.go
+++ b/provider/resource_opensearch_ism_policy.go
@@ -79,7 +79,7 @@ func resourceOpensearchISMPolicyRead(d *schema.ResourceData, m interface{}) erro
 
 	if err != nil {
 		if elastic6.IsNotFound(err) || elastic7.IsNotFound(err) {
-			log.Printf("[WARN] Opensearch Policy (%s) not found, removing from state", d.Id())
+			log.Printf("[WARN] OpenSearch Policy (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/provider/resource_opensearch_ism_policy_mapping.go
+++ b/provider/resource_opensearch_ism_policy_mapping.go
@@ -53,7 +53,7 @@ var openDistroISMPolicyMappingSchema = map[string]*schema.Schema{
 
 func resourceOpenSearchISMPolicyMapping() *schema.Resource {
 	return &schema.Resource{
-		Description: "Provides an OpenSearch Index State Management (ISM) policy. Please refer to the OpenSearch ISM documentation for details.",
+		Description: "Provides an OpenSearch Index State Management (ISM) policy. Please refer to the OpenSearch ISM documentation for details.\n\n!> `opensearch_ism_policy_mapping` is deprecated in OpenSearch 1.x please use the `opensearch_ism_policy` resource and specify the `ism_template` attribute in the policies instead.",
 		Create:      resourceOpensearchOpenDistroISMPolicyMappingCreate,
 		Read:        resourceOpensearchOpenDistroISMPolicyMappingRead,
 		Update:      resourceOpensearchOpenDistroISMPolicyMappingUpdate,
@@ -66,7 +66,7 @@ func resourceOpenSearchISMPolicyMapping() *schema.Resource {
 			Create: schema.DefaultTimeout(5 * time.Minute),
 			Update: schema.DefaultTimeout(5 * time.Minute),
 		},
-		DeprecationMessage: "opensearch_ism_policy_mapping is deprecated in Opensearch 1.x please use the opensearch_ism_policy resource and specify the ism_template attribute in the policies instead.",
+		DeprecationMessage: "opensearch_ism_policy_mapping is deprecated in OpenSearch 1.x please use the opensearch_ism_policy resource and specify the ism_template attribute in the policies instead.",
 	}
 }
 

--- a/provider/resource_opensearch_sm_policy_test.go
+++ b/provider/resource_opensearch_sm_policy_test.go
@@ -24,7 +24,7 @@ func TestAccOpensearchSMPolicy(t *testing.T) {
 			testAccPreCheck(t)
 
 			if !allowed {
-				t.Skip("OpenSearch Snapshot Management only supported on Opensearch >= 2.1")
+				t.Skip("OpenSearch Snapshot Management only supported on OpenSearch >= 2.1")
 			}
 		},
 		Providers:    testAccOpendistroProviders,


### PR DESCRIPTION
### Description
- some examples were based on legacy Elasticsearch version
- switch to string instead of number to match the OpenSearch type
- add deprecation message to opensearch_ism_policy_mapping

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
