### PR TITLE
Adding rblcoder as maintainer and codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @peterzhuamazon @prudhvigodithi @jackson-theisen @phillbaker
+* @peterzhuamazon @prudhvigodithi @jackson-theisen @phillbaker @rblcoder

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,3 +10,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Prudhvi Godithi | [prudhvigodithi](https://github.com/prudhvigodithi)   | Amazon               |
 | jackson Theisen | [jackson-theisen](https://github.com/jackson-theisen) | External contributor  |
 | Phillip Baker   | [phillbaker](https://github.com/phillbaker)           | External contributor |
+| Rupa Lahiri   | [rblcoder](https://github.com/rblcoder)           | External contributor |


### PR DESCRIPTION
### Description
Rupa was chosen to join as a maintainer after reviewing her work for the terraform provider. :clap:

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
