### PR TITLE
Update version of GoReleaser to v1.23.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2.1.1
       with:
-        version: latest
+        version: v1.23.0
         args: release --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description
The release action failed with GoReleaser `v1.24.0`
GoReleaser version found: v1.24.0
https://github.com/opensearch-project/terraform-provider-opensearch/actions/runs/8526216243/job/23355818816

The release action passed with GoReleaser `v1.23.0`
GoReleaser version found:  v1.23.0
https://github.com/opensearch-project/terraform-provider-opensearch/actions/runs/7424989946/job/20205920756

In the following block the `latest` automatically updates the GoReleaser, I have changed to the working one `v1.23.0`.
```
    - name: Run GoReleaser
      uses: goreleaser/goreleaser-action@v2.1.1
      with:
        version: latest
        args: release --rm-dist
```

### Issues Resolved
https://github.com/opensearch-project/terraform-provider-opensearch/issues/172

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
