### PR TITLE
Add multi-tenancy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [Copyright](#copyright)
 
 ## Terraform Provider OpenSearch
+
 This is a terraform provider to provision OpenSearch resources.
 
 ### Supported Functionalities 
@@ -35,7 +36,6 @@ Examples of resources can be found in the examples directory.
 - [x] [Alerting Monitors](https://opensearch.org/docs/latest/observing-your-data/alerting/monitors/)
 - [x] [Notification Channels](https://opensearch.org/docs/latest/observing-your-data/notifications/index/)
 
-
 ### Running tests locally
 
 ```sh
@@ -47,9 +47,11 @@ export OPENSEARCH_URL=http://admin:admin@localhost:9200
 export TF_LOG=INFO
 TF_ACC=1 go test ./... -v -parallel 20 -cover -short
 ```
+
 Note:  Starting from version `2.12.0`, the `admin` user password is determined by the `OPENSEARCH_INITIAL_ADMIN_PASSWORD` environment variable. If testing against a cluster with version `2.12.0` or later and have set `OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123@456`, please update the URL as follows: `export OPENSEARCH_URL=http://admin:myStrongPassword123%40456@localhost:9200`
 
 #### To Run Specific Test
+
 ```sh
 cd provider/
 TF_ACC=2 go test -run TestAccOpensearchOpenDistroDashboardTenant  -v -cover -short
@@ -60,7 +62,6 @@ TF_ACC=2 go test -run TestAccOpensearchOpenDistroDashboardTenant  -v -cover -sho
 ```sh
 golangci-lint run --out-format=github-actions 
 ```
-
 
 ### Debugging this provider
 
@@ -86,13 +87,16 @@ $ terraform apply
 The local provider will be used instead, and you should see debug information printed to the terminal.
 
 ## Version and Branching
+
 As of now, this terraform-provider-opensearch repository maintains 2 branches:
-* _main_ (2.x.x OpenSearch development)
-* _1.x_ (1.x.x OpenSearch development)
+
+- _main_ (2.x.x OpenSearch development)
+- _1.x_ (1.x.x OpenSearch development)
 
 Contributors should choose the corresponding branch(es) when commiting their change(s):
-* If you have a change for a specific version, only open PR to specific branch
-* If you have a change for all available versions, first open a PR on `main`, then open a backport PR with `[x]` in the title, with label `backport 1.x`, etc.
+
+- If you have a change for a specific version, only open PR to specific branch
+- If you have a change for all available versions, first open a PR on `main`, then open a backport PR with `[x]` in the title, with label `backport 1.x`, etc.
 
 ## Contributing
 

--- a/docs/resources/dashboard_object.md
+++ b/docs/resources/dashboard_object.md
@@ -14,7 +14,8 @@ Provides an OpenSearch Dashboards object resource. This resource interacts direc
 
 ```terraform
 resource "opensearch_dashboard_object" "test_visualization_v6" {
-  body = <<EOF
+  tenant_name = "tenant"
+  body        = <<EOF
 [
   {
     "_id": "visualization:response-time-percentile",
@@ -36,7 +37,8 @@ EOF
 
 
 resource "opensearch_dashboard_object" "test_visualization_v7" {
-  body = <<EOF
+  tenant_name = "tenant"
+  body        = <<EOF
 [
   {
     "_id": "response-time-percentile",
@@ -56,7 +58,8 @@ EOF
 }
 
 resource "opensearch_dashboard_object" "test_index_pattern_v6" {
-  body = <<EOF
+  tenant_name = "tenant"
+  body        = <<EOF
 [
   {
     "_id": "index-pattern:cloudwatch",
@@ -74,7 +77,8 @@ EOF
 }
 
 resource "opensearch_dashboard_object" "test_index_pattern_v7" {
-  body = <<EOF
+  tenant_name = "tenant"
+  body        = <<EOF
 [
   {
     "_id": "index-pattern:cloudwatch",
@@ -101,7 +105,8 @@ EOF
 
 ### Optional
 
-- `index` (String) The name of the index where dashboard data is stored.
+- `index` (String) The name of the index where dashboard data is stored. Does not work with tenant_name.
+- `tenant_name` (String) The name of the tenant to which dashboard data associate. Empty string defaults to global tenant.
 
 ### Read-Only
 

--- a/examples/resources/opensearch_dashboard_object/resource.tf
+++ b/examples/resources/opensearch_dashboard_object/resource.tf
@@ -1,6 +1,7 @@
 
 resource "opensearch_dashboard_object" "test_visualization_v6" {
-  body = <<EOF
+  tenant_name = "tenant"
+  body        = <<EOF
 [
   {
     "_id": "visualization:response-time-percentile",
@@ -22,7 +23,8 @@ EOF
 
 
 resource "opensearch_dashboard_object" "test_visualization_v7" {
-  body = <<EOF
+  tenant_name = "tenant"
+  body        = <<EOF
 [
   {
     "_id": "response-time-percentile",
@@ -42,7 +44,8 @@ EOF
 }
 
 resource "opensearch_dashboard_object" "test_index_pattern_v6" {
-  body = <<EOF
+  tenant_name = "tenant"
+  body        = <<EOF
 [
   {
     "_id": "index-pattern:cloudwatch",
@@ -60,7 +63,8 @@ EOF
 }
 
 resource "opensearch_dashboard_object" "test_index_pattern_v7" {
-  body = <<EOF
+  tenant_name = "tenant"
+  body        = <<EOF
 [
   {
     "_id": "index-pattern:cloudwatch",

--- a/provider/resource_opensearch_dashboard_object.go
+++ b/provider/resource_opensearch_dashboard_object.go
@@ -6,10 +6,15 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 
 	elastic7 "github.com/olivere/elastic/v7"
+)
+
+const (
+	SECURITY_TENANT_HEADER = "securitytenant"
 )
 
 func resourceOpensearchDashboardObject() *schema.Resource {
@@ -19,6 +24,20 @@ func resourceOpensearchDashboardObject() *schema.Resource {
 		Read:        resourceOpensearchDashboardObjectRead,
 		Update:      resourceOpensearchDashboardObjectUpdate,
 		Delete:      resourceOpensearchDashboardObjectDelete,
+		CustomizeDiff: customdiff.ForceNewIfChange(
+			"body",
+			// force recreation if _id of object changed
+			func(ctx context.Context, old, new, meta interface{}) bool {
+				dashboardObjectOld, err := readBodyInterface(old)
+				if err != nil {
+					return false
+				}
+				dashboardObjectNew, err := readBodyInterface(new)
+				if err != nil {
+					return false
+				}
+				return !(dashboardObjectOld["_id"] == dashboardObjectNew["_id"])
+			}),
 		Schema: map[string]*schema.Schema{
 			"body": {
 				Type:     schema.TypeString,
@@ -43,250 +62,253 @@ func resourceOpensearchDashboardObject() *schema.Resource {
 
 					for _, o := range body {
 						dashboardObject, ok := o.(map[string]interface{})
-
 						if !ok {
 							errors = append(errors, fmt.Errorf("entries must be objects"))
 							continue
 						}
 
-						for _, k := range requiredDashboardObjectKeys() {
+						for _, k := range []string{"_source", "_id"} {
 							if dashboardObject[k] == nil {
 								errors = append(errors, fmt.Errorf("object must have the %q key", k))
 							}
 						}
 					}
-
 					return warnings, errors
 				},
-				// DiffSuppressFunc: diffSuppressDashboardObject,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
 				},
 				Description: "The JSON body of the dashboard object.",
 			},
+			"tenant_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Default:     "",
+				Description: "The name of the tenant to which dashboard data associate. Empty string defaults to global tenant.",
+			},
 			"index": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				ForceNew:    true,
 				Default:     ".kibana",
-				Description: "The name of the index where dashboard data is stored.",
+				Description: "The name of the index where dashboard data is stored. Does not work with tenant_name.",
 			},
 		},
 	}
 }
 
-const (
-	INDEX_CREATED int = iota
-	INDEX_EXISTS
-	INDEX_CREATION_FAILED
-)
-
 func resourceOpensearchDashboardObjectCreate(d *schema.ResourceData, meta interface{}) error {
-	index := d.Get("index").(string)
-	mapping_index := d.Get("index").(string)
-
-	var success int
-	var err error
-	osClient, err := getClient(meta.(*ProviderConf))
+	// parse desired terrafrom state
+	state, err := readDashboardObjectState(d)
 	if err != nil {
 		return err
 	}
-	success, err = elastic7CreateIndexIfNotExists(osClient, index, mapping_index)
-
+	client, err := getClient(meta.(*ProviderConf))
 	if err != nil {
-		log.Printf("[INFO] Failed to create new Dashboard index: %+v", err)
-		return err
+		return fmt.Errorf("Could not read client: %+v", err)
 	}
 
-	if success == INDEX_CREATED {
-		log.Printf("[INFO] Created new Dashboard index")
-	} else if success == INDEX_CREATION_FAILED {
-		return fmt.Errorf("fail to create OpenSearchsearch index")
+	// make OpenSearch API calls
+	if err = elastic7CreateIndexIfNotExists(client, state.index); err != nil {
+		return fmt.Errorf("Failed to create new Dashboard index: %+v", err)
 	}
-
-	id, err := resourceOpensearchPutDashboardObject(d, meta)
-
+	resp, err := state.elastic7PutDashboardObject(client)
 	if err != nil {
-		log.Printf("[INFO] Failed to put Dashboard object: %+v", err)
-		return err
+		return fmt.Errorf("Failed to put Dashboard object: %+v", err)
 	}
 
-	d.SetId(id)
-	log.Printf("[INFO] Object ID: %s", d.Id())
-
-	return nil
-}
-
-func elastic7CreateIndexIfNotExists(client *elastic7.Client, index string, mappingIndex string) (int, error) {
-	log.Printf("[INFO] elastic7CreateIndexIfNotExists %s", index)
-
-	// Use the IndexExists service to check if a specified index exists.
-	exists, err := client.IndexExists(index).Do(context.TODO())
-	if err != nil {
-		return INDEX_CREATION_FAILED, err
-	}
-	if !exists {
-		createIndex, err := client.CreateIndex(mappingIndex).Body(`{"mappings":{}}`).Do(context.TODO())
-		if createIndex.Acknowledged {
-			return INDEX_CREATED, err
-		}
-		return INDEX_CREATION_FAILED, err
-	}
-
-	return INDEX_EXISTS, nil
+	// set computed value
+	d.SetId(resp.Id)
+	return resourceOpensearchDashboardObjectRead(d, meta)
 }
 
 func resourceOpensearchDashboardObjectRead(d *schema.ResourceData, meta interface{}) error {
-	bodyString := d.Get("body").(string)
-	var body []interface{}
-	if err := json.Unmarshal([]byte(bodyString), &body); err != nil {
-		log.Printf("[WARN] Failed to unmarshal on read: %+v", bodyString)
-		return err
-	}
-	dashboardObject, ok := body[0].(map[string]interface{})
-	if !ok {
-		return fmt.Errorf("expected %v to be an object", body[0])
-	}
-	id := dashboardObject["_id"].(string)
-	index := d.Get("index").(string)
-
-	var resultJSON []byte
-	var err error
-	osClient, err := getClient(meta.(*ProviderConf))
+	// parse current terraform state
+	state, err := readDashboardObjectState(d)
 	if err != nil {
 		return err
 	}
-	var result *elastic7.GetResult
-	result, err = elastic7GetObject(osClient, index, id)
-	if err == nil {
-		resultJSON, err = json.Marshal(result)
+	client, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
 	}
 
+	// fetch object from OpenSearch
+	result, err := state.elastic7GetDashboardObject(client)
 	if err != nil {
 		if elastic7.IsNotFound(err) {
-			log.Printf("[WARN] Dashboard Object (%s) not found, removing from state", id)
+			log.Printf("[WARN] Dashboard Object (%s) not found, removing from state", state.id)
 			d.SetId("")
 			return nil
 		}
+		return fmt.Errorf("Could not read state from OpenSearch: %+v", err)
+	}
 
-		return err
+	// build json string from response that represents body configuration
+	// Note that only the 'original' keys are considered. Keys that
+	// OpenSearch adds internally will be ignored (e.g. 'updated_at').
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("Failed to marshal result: %+v", err)
 	}
 	log.Printf("[TRACE] body: %s", string(resultJSON))
 
-	ds := &resourceDataSetter{d: d}
-	ds.set("index", index)
-
-	// The Dashboard object interface was originally built with the notion that
-	// multiple Dashboard objects would be specified in the same resource, however,
-	// that's not practical given that the OpenSearch API is for a single
-	// object. We account for that here: use the _source attribute and build a
-	// single entry array
 	var originalKeys []string
-	for k := range dashboardObject {
+	for k := range state.dashboardObject {
 		originalKeys = append(originalKeys, k)
 	}
 
 	res := make(map[string]interface{})
 	if err := json.Unmarshal(resultJSON, &res); err != nil {
-		log.Printf("[WARN] Failed to unmarshal: %+v", resultJSON)
-		return err
+		return fmt.Errorf("Failed to unmarshal '%+v': %+v", resultJSON, err)
 	}
 
 	stateObject := []map[string]interface{}{make(map[string]interface{})}
 	for _, k := range originalKeys {
 		stateObject[0][k] = res[k]
 	}
-	state, err := json.Marshal(stateObject)
+	bodyBytes, err := json.Marshal(stateObject)
 	if err != nil {
-		return fmt.Errorf("error marshalling resource data: %+v", err)
+		return fmt.Errorf("Failed marshalling resource data: %+v", err)
 	}
-	ds.set("body", string(state))
+
+	// update terraform state based on fetched data. Fields other than 'body' do
+	// not need to be updated as chanages in these fields result in 'NotFound'
+	ds := &resourceDataSetter{d: d}
+	ds.set("body", string(bodyBytes))
 
 	return ds.err
 }
 
 func resourceOpensearchDashboardObjectUpdate(d *schema.ResourceData, meta interface{}) error {
-	_, err := resourceOpensearchPutDashboardObject(d, meta)
-	return err
+	// parse desired terraform state
+	state, err := readDashboardObjectState(d)
+	if err != nil {
+		return err
+	}
+	client, err := getClient(meta.(*ProviderConf))
+	if err != nil {
+		return err
+	}
+
+	// update data in OpenSearch via put request
+	resp, err := state.elastic7PutDashboardObject(client)
+	if err != nil {
+		return fmt.Errorf("Dashboard object update failed: %+v", err)
+	}
+
+	// update computed values
+	d.SetId(resp.Id)
+	return resourceOpensearchDashboardObjectRead(d, meta)
 }
 
 func resourceOpensearchDashboardObjectDelete(d *schema.ResourceData, meta interface{}) error {
-	bodyString := d.Get("body").(string)
-	var body []interface{}
-	if err := json.Unmarshal([]byte(bodyString), &body); err != nil {
-		log.Printf("[WARN] Failed to unmarshal: %+v", bodyString)
-		return err
-	}
-	object, ok := body[0].(map[string]interface{})
-	if !ok {
-		return fmt.Errorf("expected %v to be an object", body[0])
-	}
-	id := object["_id"].(string)
-	index := d.Get("index").(string)
-
-	var err error
-	osClient, err := getClient(meta.(*ProviderConf))
+	// read old values. note that readDashboardObjectState(d) would read new state
+	client, err := getClient(meta.(*ProviderConf))
 	if err != nil {
 		return err
 	}
-	err = elastic7DeleteIndex(osClient, index, id)
+	index, _ := d.GetChange("index")
+	tenantName, _ := d.GetChange("tenant_name")
 
+	// make delete api call
+	return elastic7DeleteDashboardObject(client, index.(string), d.Id(), tenantName.(string))
+}
+
+func elastic7CreateIndexIfNotExists(client *elastic7.Client, index string) error {
+	log.Printf("[INFO] elastic7CreateIndexIfNotExists %s", index)
+	exists, err := client.IndexExists(index).Do(context.TODO())
 	if err != nil {
-		return err
+		return fmt.Errorf("%+v", err)
 	}
-
+	if !exists {
+		createIndex, err := client.CreateIndex(index).Body(`{"mappings":{}}`).Do(context.TODO())
+		if createIndex.Acknowledged {
+			log.Printf("[INFO] Created new Dashboard index")
+			return err
+		}
+		return fmt.Errorf("Failed to create OpenSearchsearch index: %+v", err)
+	}
 	return nil
 }
 
-func elastic7DeleteIndex(client *elastic7.Client, index string, id string) error {
-	_, err := client.Delete().
-		Index(index).
-		Id(id).
-		Do(context.TODO())
+type dashboardObjectState struct {
+	index      string
+	tenantName string
+	// body splitted into interfaces
+	dashboardObject map[string]interface{}
+	// id from body in dashboard object resource
+	id string
+}
+
+func readDashboardObjectState(d *schema.ResourceData) (*dashboardObjectState, error) {
+	dashboardObject, err := readBodyInterface(d.Get("body"))
+	if err != nil {
+		return nil, fmt.Errorf("Could not read body interface: %+v", err)
+	}
+
+	return &dashboardObjectState{
+		index:           d.Get("index").(string),
+		tenantName:      d.Get("tenant_name").(string),
+		dashboardObject: dashboardObject,
+		id:              dashboardObject["_id"].(string),
+	}, nil
+}
+
+func readBodyInterface(i interface{}) (map[string]interface{}, error) {
+	bodyString, ok := i.(string)
+	if !ok {
+		return nil, fmt.Errorf("Cannot convert input to string.")
+	}
+
+	var body []interface{}
+	if err := json.Unmarshal([]byte(bodyString), &body); err != nil {
+		return nil, fmt.Errorf("Could not unmarshal body string: %+v", err)
+	}
+	if len(body) == 0 {
+		return nil, fmt.Errorf("Body has no elements as JSON array.")
+	}
+
+	dashboardObject, ok := body[0].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("Body has unexpected format.")
+	}
+
+	return dashboardObject, nil
+}
+
+func (s *dashboardObjectState) elastic7PutDashboardObject(client *elastic7.Client) (*elastic7.IndexResponse, error) {
+	req := client.Index().Index(s.index).Id(s.id).BodyJson(s.dashboardObject["_source"])
+	if s.tenantName != "" {
+		req = req.Header(SECURITY_TENANT_HEADER, s.tenantName)
+	}
+	return req.Do(context.TODO())
+}
+
+func (s *dashboardObjectState) elastic7GetDashboardObject(client *elastic7.Client) (*elastic7.GetResult, error) {
+	req := client.Get().Index(s.index).Id(s.id)
+	if s.tenantName != "" {
+		req = req.Header(SECURITY_TENANT_HEADER, s.tenantName)
+	}
+	result, err := req.Do(context.TODO())
+	if elastic7.IsNotFound(err) {
+		return nil, err // there is a check against this error
+	}
+	if err != nil {
+		return nil, fmt.Errorf("Could not retrieve dashboard object: %+v", err)
+	}
+	return result, nil
+}
+
+func elastic7DeleteDashboardObject(client *elastic7.Client, index, id, tenantName string) error {
+	req := client.Delete().Index(index).Id(id)
+	if tenantName != "" {
+		req = req.Header(SECURITY_TENANT_HEADER, tenantName)
+	}
+	_, err := req.Do(context.TODO())
 
 	// we'll get an error if it's not found
 	return err
-}
-
-func resourceOpensearchPutDashboardObject(d *schema.ResourceData, meta interface{}) (string, error) {
-	bodyString := d.Get("body").(string)
-	var body []interface{}
-	if err := json.Unmarshal([]byte(bodyString), &body); err != nil {
-		log.Printf("[WARN] Failed to unmarshal on put: %+v", bodyString)
-		return "", err
-	}
-	object, ok := body[0].(map[string]interface{})
-	if !ok {
-		return "", fmt.Errorf("expected %v to be an object", body[0])
-	}
-	id := object["_id"].(string)
-	data := object["_source"]
-	index := d.Get("index").(string)
-
-	var err error
-	osClient, err := getClient(meta.(*ProviderConf))
-	if err != nil {
-		return "", err
-	}
-	err = elastic7PutIndex(osClient, index, id, data)
-
-	if err != nil {
-		return "", err
-	}
-
-	return id, nil
-}
-
-func elastic7PutIndex(client *elastic7.Client, index string, id string, data interface{}) error {
-	_, err := client.Index().
-		Index(index).
-		Id(id).
-		BodyJson(&data).
-		Do(context.TODO())
-
-	return err
-}
-
-func requiredDashboardObjectKeys() []string {
-	return []string{"_source", "_id"}
 }

--- a/provider/resource_opensearch_dashboard_object_test.go
+++ b/provider/resource_opensearch_dashboard_object_test.go
@@ -215,7 +215,7 @@ resource "opensearch_dashboard_object" "test_visualization" {
 	      "uiStateJSON": "{}",
 	      "description": "",
 	      "version": 1,
-	      "dashboardSavedObjectMeta": {
+	      "kibanaSavedObjectMeta": {
 	        "searchSourceJSON": "{\"index\":\"filebeat-*\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
 	      }
 	    },
@@ -249,7 +249,7 @@ resource "opensearch_dashboard_object" "test_visualization" {
 	      "uiStateJSON": "{}",
 	      "description": "",
 	      "version": 1,
-	      "dashboardSavedObjectMeta": {
+	      "kibanaSavedObjectMeta": {
 	        "searchSourceJSON": "{\"index\":\"filebeat-*\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
 	      }
 	    },

--- a/provider/util.go
+++ b/provider/util.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"bytes"
-	"context"
 	"crypto/sha256"
 	"fmt"
 	"hash/crc32"
@@ -14,28 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mitchellh/go-homedir"
-	elastic7 "github.com/olivere/elastic/v7"
 )
-
-var (
-	errObjNotFound = fmt.Errorf("object not found")
-)
-
-func elastic7GetObject(client *elastic7.Client, index string, id string) (*elastic7.GetResult, error) {
-	result, err := client.Get().
-		Index(index).
-		Id(id).
-		Do(context.TODO())
-
-	if err != nil {
-		return nil, err
-	}
-	if !result.Found {
-		return nil, errObjNotFound
-	}
-
-	return result, nil
-}
 
 func normalizeChannelConfiguration(tpl map[string]interface{}) {
 	delete(tpl, "last_updated_time_ms")


### PR DESCRIPTION
### Description

A `tenant_name` argument has been added to the `opensearch_dashboard_object` resource. It's important to note that the global tenant is referenced by an empty string "" which is also the default value. Further, 

* a test case has been added
* the code behind the `opensearch_dashboard_object` has been refactored
* a CustomizeDiff function does now enforce a recreation of the resource when `_id` within the body changes. Previously, this did not work properly and a copy of the object was created without destroying the old one.

Note that using "global_tenant" as tenant creates an object in OpenSearch but it won't be visible in the UI. Hence, one needs to use "" to reference the global tenant.

### Issues Resolved

* [Multi-tenancy configuration](https://github.com/opensearch-project/terraform-provider-opensearch/issues/104)
* [Allow tenant selection when creating Dashboard Objects](https://github.com/opensearch-project/terraform-provider-opensearch/issues/97)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
