### PR TITLE
Update goreleaser to v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,15 +116,15 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.18.x
+        go-version: 1.22.1
     - name: Import GPG key
       id: import_gpg
-      uses: crazy-max/ghaction-import-gpg@v5
+      uses: crazy-max/ghaction-import-gpg@v6
       with:
         gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
         passphrase: ${{ secrets.GPG_PASSPHRASE }}
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v2.1.1
+      uses: goreleaser/goreleaser-action@v6
       with:
         version: latest
         args: release --rm-dist

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+run:
+  go: "1.22.1"
 linters:
   enable:
     - gofmt

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,8 +1,12 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+# Version of the configuration file
+version: 2
+
 before:
   hooks:
     - go mod tidy
+
 builds:
   - env:
       - CGO_ENABLED=0
@@ -45,4 +49,4 @@ signs:
 release:
   draft: false
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
### Description

Update goreleaser to v2, coming from https://goreleaser.com/blog/goreleaser-v2/, this should resolve the error https://github.com/opensearch-project/terraform-provider-opensearch/actions/runs/9419163108/job/25948627009 and unblock the release.

The customization changelog: https://goreleaser.com/customization/changelog/?h=changelog

### Issues Resolved
Part of https://github.com/opensearch-project/terraform-provider-opensearch/issues/196

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
