### PR TITLE
Update goreleaser to v2 - Part 2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,7 @@ jobs:
       uses: goreleaser/goreleaser-action@v6
       with:
         version: latest
-        args: release --rm-dist
+        args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}


### PR DESCRIPTION
### Description
Coming from initial PR https://github.com/opensearch-project/terraform-provider-opensearch/pull/197. This should fix the error ` error=unknown flag: --rm-dist`. The document suggests to use `--clean`  https://github.com/goreleaser/goreleaser-action

### Issues Resolved
Part of https://github.com/opensearch-project/terraform-provider-opensearch/issues/196

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
