### PR TITLE
Update/fix github workflow actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         # we depend on full git history for linters
         fetch-depth: 0
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v6
       with:
         # Required: the version of golangci-lint is required and must be
         # specified without patch version: we always use the latest patch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
         # we depend on full git history for linters
         fetch-depth: 0
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/go/pkg/mod              # Module download cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         # Required: the version of golangci-lint is required and must be
         # specified without patch version: we always use the latest patch
         # version.
-        version: v1.54
+        version: v1.64
         args: --verbose --timeout=10m
   test:
     strategy:


### PR DESCRIPTION
### Description
Attempt to fix the failing Github workflow actions. Specifically:
- The [Set up job](https://github.com/opensearch-project/terraform-provider-opensearch/actions/runs/13268597729/job/37042531519) failure for the latest build on the `main` branch
- The [linters job](https://github.com/opensearch-project/terraform-provider-opensearch/actions/runs/13825452532/job/38679436316?pr=240) failure on the most recent [dependabot PR](https://github.com/opensearch-project/terraform-provider-opensearch/pull/240)

### Issues Resolved
Hopefully resolves these build failures, though I might have to play whack-a-mole on other failures after the Github workflows run for this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
