### PR TITLE
Fix/suppress functionally equivalent mappings differences

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         # we depend on full git history for linters
         fetch-depth: 0
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v6
       with:
         # Required: the version of golangci-lint is required and must be
         # specified without patch version: we always use the latest patch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
         # we depend on full git history for linters
         fetch-depth: 0
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/go/pkg/mod              # Module download cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         # Required: the version of golangci-lint is required and must be
         # specified without patch version: we always use the latest patch
         # version.
-        version: v1.54
+        version: v1.64
         args: --verbose --timeout=10m
   test:
     strategy:

--- a/provider/resource_opensearch_index.go
+++ b/provider/resource_opensearch_index.go
@@ -371,6 +371,9 @@ var (
 			Optional:     true,
 			ForceNew:     true,
 			ValidateFunc: validation.StringIsJSON,
+			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				return functionallyEquivalentJSON(old, new)
+			},
 		},
 		"aliases": {
 			Type:        schema.TypeString,

--- a/provider/resource_opensearch_index_test.go
+++ b/provider/resource_opensearch_index_test.go
@@ -150,6 +150,21 @@ resource "opensearch_index" "test_doctype" {
   )
 }
 `
+	testAccOpensearchMappingsWhitespaceStability = `
+resource "opensearch_index" "test_mappings_whitespace_stability" {
+  name               = "terraform-test"
+  number_of_replicas = "1"
+  mappings = <<EOF
+{
+  "properties" : {
+    "foo" : {
+      "type" : "text"
+    }
+  }
+}
+EOF
+}
+`
 	testAccOpensearchIndexUpdateForceDestroy = `
 resource "opensearch_index" "test" {
   name               = "terraform-test"
@@ -528,6 +543,29 @@ func TestAccOpensearchIndex_knnAlgoParamEFSearchConfig(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					checkOpensearchIndexExists("opensearch_index.test_knn_algo_param_ef_search_config"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccOpensearchIndex_mappingsWhitespaceStability(t *testing.T) {
+	var config string = testAccOpensearchMappingsWhitespaceStability
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: checkOpensearchIndexDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkOpensearchIndexExists("opensearch_index.test_mappings_whitespace_stability"),
+				),
+			},
+			{
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})

--- a/provider/resource_opensearch_index_test.go
+++ b/provider/resource_opensearch_index_test.go
@@ -165,6 +165,42 @@ resource "opensearch_index" "test_mappings_whitespace_stability" {
 EOF
 }
 `
+	testAccOpensearchMappingFunctionallyEquivalent1 = `
+resource "opensearch_index" "test_functionally_equivalent_mappings" {
+  name               = "terraform-test"
+  number_of_replicas = "1"
+  mappings = <<EOF
+{
+  "properties" : {
+    "foo" : {
+      "type" : "text"
+    },
+    "bar" : {
+      "type" : "text"
+    }
+  }
+}
+EOF
+}
+`
+	testAccOpensearchMappingFunctionallyEquivalent2 = `
+resource "opensearch_index" "test_functionally_equivalent_mappings" {
+  name               = "terraform-test"
+  number_of_replicas = "1"
+  mappings = <<EOF
+{
+  "properties" : {
+    "bar" : {
+      "type" : "text"
+    },
+    "foo" : {
+      "type" : "text"
+    }
+  }
+}
+EOF
+}
+`
 	testAccOpensearchIndexUpdateForceDestroy = `
 resource "opensearch_index" "test" {
   name               = "terraform-test"
@@ -564,6 +600,27 @@ func TestAccOpensearchIndex_mappingsWhitespaceStability(t *testing.T) {
 			},
 			{
 				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestAccOpensearchIndex_functionallyEquivalentMappings(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: checkOpensearchIndexDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpensearchMappingFunctionallyEquivalent1,
+				Check: resource.ComposeTestCheckFunc(
+					checkOpensearchIndexExists("opensearch_index.test_functionally_equivalent_mappings"),
+				),
+			},
+			{
+				Config:             testAccOpensearchMappingFunctionallyEquivalent2,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},

--- a/provider/util.go
+++ b/provider/util.go
@@ -3,10 +3,12 @@ package provider
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"hash/crc32"
 	"log"
 	"os"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -178,6 +180,17 @@ func containsString(h []string, n string) bool {
 		}
 	}
 	return false
+}
+
+func functionallyEquivalentJSON(j1, j2 string) bool {
+	var unmarshaled1, unmarshaled2 map[string]interface{}
+	if err := json.Unmarshal([]byte(j1), &unmarshaled1); err != nil {
+		return false
+	}
+	if err := json.Unmarshal([]byte(j2), &unmarshaled2); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(unmarshaled1, unmarshaled2)
 }
 
 // Takes the result of flatmap.Expand for an array of strings


### PR DESCRIPTION
### Description
Fix resource instability caused by non-functional index mappings changes (whitespace changes, JSON key ordering changes, etc).

I added two test cases that fail on current `main` due to non-functional index mappings changes. They now pass with the `DiffSuppressFunc` using an added `functionallyEquivalentJSON` helper function.

Note: this also includes my changes in https://github.com/opensearch-project/terraform-provider-opensearch/pull/241 as I needed them to get the test suite running for these fixes.

### Issues Resolved
Fixes https://github.com/opensearch-project/terraform-provider-opensearch/issues/237

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
