### PR TITLE
Make `opensearch_cluster_settings` deletion a no-op.

### DIFF
--- a/docs/resources/cluster_settings.md
+++ b/docs/resources/cluster_settings.md
@@ -67,11 +67,10 @@ resource "opensearch_cluster_settings" "global" {
 - `indices_recovery_max_bytes_per_sec` (String) Maximum total inbound and outbound recovery traffic for each node, in mb
 - `network_breaker_inflight_requests_limit` (String) The percentage limit of memory usage on a node of all currently active incoming requests on transport or HTTP level
 - `network_breaker_inflight_requests_overhead` (Number) A constant that all in flight requests estimations are multiplied by
+- `reset_settings_on_delete` (Boolean) If true, cluster settings will be reset to defaults when this resource is deleted
 - `script_max_compilations_rate` (String) Limit for the number of unique dynamic scripts within a certain interval that are allowed to be compiled, expressed as compilations divided by a time string
 - `search_default_search_timeout` (String) A time string setting a cluster-wide default timeout for all search requests
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-
-

--- a/provider/resource_opensearch_cluster_settings.go
+++ b/provider/resource_opensearch_cluster_settings.go
@@ -290,6 +290,12 @@ func resourceOpensearchClusterSettings() *schema.Resource {
 				Optional:    true,
 				Description: "A constant that all in flight requests estimations are multiplied by",
 			},
+			"reset_settings_on_delete": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "If true, cluster settings will be reset to defaults when this resource is deleted",
+			},
 			"script_max_compilations_rate": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -369,13 +375,15 @@ func resourceOpensearchClusterSettingsUpdate(d *schema.ResourceData, meta interf
 }
 
 func resourceOpensearchClusterSettingsDelete(d *schema.ResourceData, meta interface{}) error {
-	err := clearAllSettings(meta)
-	if err != nil {
-		return err
+	if d.Get("reset_settings_on_delete").(bool) {
+		err := clearAllSettings(meta)
+		if err != nil {
+			return err
+		}
 	}
 
 	d.SetId("")
-	return err
+	return nil
 }
 
 func resourceOpensearchClusterSettingsGet(meta interface{}) (map[string]interface{}, error) {

--- a/provider/resource_opensearch_cluster_settings_test.go
+++ b/provider/resource_opensearch_cluster_settings_test.go
@@ -118,6 +118,7 @@ func checkOpensearchClusterSettingsDestroy(s *terraform.State) error {
 
 var testAccOpensearchClusterSettings = `
 resource "opensearch_cluster_settings" "global" {
+  reset_settings_on_delete          = true
   cluster_max_shards_per_node       = 10
   cluster_routing_allocation_enable = "all"
   action_auto_create_index          = "my-index-000001,index10,-index1*,+ind*,-.aws_cold_catalog*,+*"
@@ -126,12 +127,15 @@ resource "opensearch_cluster_settings" "global" {
 
 var testAccOpensearchClusterSettingsSlowLog = `
 resource "opensearch_cluster_settings" "global" {
-  cluster_search_request_slowlog_level       = "WARN"
+  reset_settings_on_delete                      = true
+  cluster_search_request_slowlog_level          = "WARN"
   cluster_search_request_slowlog_threshold_warn = "10s"
 }
 `
+
 var testAccOpensearchClusterSettingsTypeList = `
 resource "opensearch_cluster_settings" "global" {
+  reset_settings_on_delete                               = true
   cluster_routing_allocation_awareness_force_zone_values = ["zone1", "zone2", "zone3"]
 }
 `


### PR DESCRIPTION
### Description

Deletion currently clobbers all settings back to defaults. There are two problems with this:

1) If someone wants to stop using `opensearch_cluster_settings` to manage cluster settings for any reason, they will end up wiping all of their cluster's settings. This is both extremely surprising and pretty terrible if they were planning on continuing to use that cluster.

2) The cluster has to be reachable for deletion to go through, complicating turndown.

Local test instructions are broken atm (https://github.com/opensearch-project/terraform-provider-opensearch/issues/248) but hopefully some sort of CI kicks off when I create this pull request?

### Issues Resolved

Resolves https://github.com/opensearch-project/terraform-provider-opensearch/issues/243
