### PR TITLE
Update actions/cache to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
         # we depend on full git history for linters
         fetch-depth: 0
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/go/pkg/mod              # Module download cache


### PR DESCRIPTION
### Description
Update actions/cache to v4, seen CI failures part of https://github.com/opensearch-project/terraform-provider-opensearch/pull/249.

### Issues Resolved
- https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
- Failed CI https://github.com/opensearch-project/terraform-provider-opensearch/actions/runs/14517209497/job/40753841278?pr=249

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
