### PR TITLE
fix!: dashboard object created in wrong index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /vendor
 .DS_Store
+.vscode/
 terraform-provider-opensearch
+__debug*

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 <img src="https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_default.svg" height="64px"/>
 
-- [Terraform Provider OpenSearch](#Terraform-Provider-OpenSearch)
-- [Compatibility](#compatibility)
+- [Terraform Provider OpenSearch](#terraform-provider-opensearch)
+  - [Supported Functionalities](#supported-functionalities)
+    - [OpenSearch and OpenSearch Dashboards](#opensearch-and-opensearch-dashboards)
+  - [Running tests locally](#running-tests-locally)
+    - [To Run Specific Test](#to-run-specific-test)
+    - [Fix the go-lint errors](#fix-the-go-lint-errors)
+  - [Debugging this provider](#debugging-this-provider)
 - [Version and Branching](#version-and-branching)
 - [Contributing](#contributing)
-- [Maintainer Responsibilities](MAINTAINERS.md)
 - [Getting Help](#getting-help)
 - [Code of Conduct](#code-of-conduct)
 - [Security](#security)
@@ -39,11 +43,12 @@ Examples of resources can be found in the examples directory.
 ### Running tests locally
 
 ```sh
-./script/install-tools
 export OSS_IMAGE="opensearchproject/opensearch:2"
-docker-compose up -d
-docker-compose ps -a  # Checks that the process is running
-export OPENSEARCH_URL=http://admin:admin@localhost:9200
+docker compose up -d
+docker compose ps -a  # Checks that the process is running
+# Before OS 2.12.0
+# export OPENSEARCH_URL=http://admin:admin@localhost:9200
+export OPENSEARCH_URL=http://admin:myStrongPassword123%40456@localhost:9200
 export TF_LOG=INFO
 TF_ACC=1 go test ./... -v -parallel 20 -cover -short
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
-version: '3'
-
 services:
   opensearch:
-    image:  ${OSS_IMAGE}
+    image:  ${OSS_IMAGE:-opensearchproject/opensearch:2}
     hostname: opensearch
     container_name: opensearch
     networks: 
@@ -18,7 +16,7 @@ services:
       - "OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123@456"
       - "plugins.security.ssl.http.enabled=false"
       - ${OSS_ENV_VAR:-FOO=bar}
-    command: ${OS_COMMAND}
+    command: ${OS_COMMAND:-}
     ulimits:
       nproc: 65536
       nofile:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opensearch-project/terraform-provider-opensearch
 
-go 1.22.1
+go 1.22.12
 
 require (
 	github.com/aws/aws-sdk-go v1.52.2

--- a/main.go
+++ b/main.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"context"
 	"flag"
-	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
@@ -19,19 +17,9 @@ func main() {
 	flag.BoolVar(&debugMode, "debuggable", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
 
-	if debugMode {
-		//nolint:staticcheck // SA1019 ignore this!
-		err := plugin.Debug(context.Background(), "registry.terraform.io/opensearch-project/opensearch",
-			&plugin.ServeOpts{
-				ProviderFunc: provider.Provider,
-			},
-		)
-		if err != nil {
-			log.Println(err.Error())
-		}
-	} else {
-		plugin.Serve(&plugin.ServeOpts{
-			ProviderFunc: provider.Provider,
-		})
-	}
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: provider.Provider,
+		ProviderAddr: "registry.terraform.io/opensearch-project/opensearch",
+		Debug:        debugMode,
+	})
 }

--- a/provider/resource_opensearch_dashboard_object.go
+++ b/provider/resource_opensearch_dashboard_object.go
@@ -82,18 +82,20 @@ func resourceOpensearchDashboardObject() *schema.Resource {
 				Description: "The JSON body of the dashboard object.",
 			},
 			"tenant_name": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Default:     "",
-				Description: "The name of the tenant to which dashboard data associate. Empty string defaults to global tenant.",
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Default:       "",
+				Description:   "The name of the tenant to which dashboard data associate. Empty string defaults to global tenant.",
+				ConflictsWith: []string{"index"},
 			},
 			"index": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Default:     ".kibana",
-				Description: "The name of the index where dashboard data is stored. Does not work with tenant_name.",
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Default:       "",
+				Description:   "The name of the index where dashboard data is stored. Does not work with tenant_name.",
+				ConflictsWith: []string{"tenant_name"},
 			},
 		},
 	}
@@ -248,10 +250,23 @@ func readDashboardObjectState(d *schema.ResourceData) (*dashboardObjectState, er
 	if err != nil {
 		return nil, fmt.Errorf("Could not read body interface: %+v", err)
 	}
-
+	// Calculate index if tenantName is given
+	indexName := d.Get("index").(string)
+	tenantName := d.Get("tenant_name").(string)
+	if tenantName != "" {
+		indexName, err = resourceOpensearchOpenDistroDashboardComputeIndex(tenantName)
+		if err != nil {
+			return nil, fmt.Errorf("could not compute tenant name: %+v", err)
+		}
+	}
+	// Default to .kibana
+	if indexName == "" {
+		indexName = ".kibana"
+	}
+	// Default
 	return &dashboardObjectState{
-		index:           d.Get("index").(string),
-		tenantName:      d.Get("tenant_name").(string),
+		index:           indexName,
+		tenantName:      tenantName,
 		dashboardObject: dashboardObject,
 		id:              dashboardObject["_id"].(string),
 	}, nil


### PR DESCRIPTION
BREAKING CHANGE: removal of `index` default forces replacement when only `tenant_name` was used or `index` was not set.

### Description
This fix ensures index patterns are created in the correct index. The previous logic was buggy when using `tenant_name`.
When doing the lookup for existing resource the provider always used `.kibana` index which is wrong when using `tenant_name`.
<img width="721" height="477" alt="image" src="https://github.com/user-attachments/assets/749014db-ef81-4c75-9421-f81a04ee0b6f" />

### Issues Resolved
No existing issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
