### PR TITLE
tests: add tests for data stream import

### DIFF
--- a/provider/resource_opensearch_data_stream_test.go
+++ b/provider/resource_opensearch_data_stream_test.go
@@ -9,6 +9,48 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+const (
+	testOpensearchDataStreamImport = `
+  resource "opensearch_data_stream" "test1import" {
+    name = "terraform-test1import"
+    depends_on = [
+      opensearch_index_template.test1import
+    ]
+  }
+  resource "opensearch_index_template" "test1import" {
+    name = "terraform-test1import"
+    body = <<EOF
+          {
+          	"index_patterns": ["terraform-test1import"],
+          	"data_stream": {
+            	"timestamp_field": {
+                "name": "@timestamp"
+                }
+              }
+          }
+          EOF
+  }
+`
+)
+
+func TestAccOpensearchDataStream_importBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckOpensearchDataStreamDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testOpensearchDataStreamImport,
+			},
+			{
+				ResourceName:      "opensearch_data_stream.test1import",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccOpensearchDataStream(t *testing.T) {
 	provider := Provider()
 	diags := provider.Configure(context.Background(), &terraform.ResourceConfig{})


### PR DESCRIPTION
### Description

Adds a test for data stream import.

It still needs a documentation update but when I ran `tfplugindocs` it changed a lot under `/docs` not just data streams document, and it also didn't add the Import section - I'm not sure where that's driven from.

### Issues Resolved

Closes #268 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
