### PR TITLE
add snapshot_config options which exist to the documentation

### DIFF
--- a/docs/resources/sm_policy.md
+++ b/docs/resources/sm_policy.md
@@ -67,6 +67,10 @@ resource "opensearch_sm_policy" "snapshot_to_s3" {
       "timezone"   = "UTC"
       "indices"    = "*"
       "repository" = opensearch_snapshot_repository.repo.name
+      "ignore_unavailable" : "true",
+      "include_global_state" : "false",
+      "date_format" : "yyyy-MM-dd-HH:mm",
+      "partial" : "false"
     }
   })
 }


### PR DESCRIPTION
### Description
This only updates the available options under snapshot_config like include_global_state etc. This is nice to have for people just looking at the terraform provider examples.

We encountered this during a restore test where we wanted the global state but didn't see it as an option in the provider.