### PR TITLE
allow index analysis attribute import

### DIFF
--- a/provider/resource_opensearch_index.go
+++ b/provider/resource_opensearch_index.go
@@ -805,6 +805,55 @@ func resourceOpensearchIndexRead(d *schema.ResourceData, meta interface{}) error
 
 	indexResourceDataFromSettings(settings, d)
 
+	// Reconstruct analysis fields from flattened keys
+	analysisData := map[string]map[string]interface{}{
+		"analyzer":    {},
+		"tokenizer":   {},
+		"filter":      {},
+		"char_filter": {},
+		"normalizer":  {},
+	}
+
+	for key, value := range settings {
+		if strings.HasPrefix(key, "index.analysis.") {
+			parts := strings.Split(strings.TrimPrefix(key, "index.analysis."), ".")
+			if len(parts) < 2 {
+				continue
+			}
+
+			category := parts[0] // should be one of analyzer, tokenizer, filter, char_filter, normalizer
+			if _, ok := analysisData[category]; !ok {
+				continue
+			}
+
+			subkeys := parts[1:]
+			// Convert string values to appropriate types for analysis configuration
+			convertedValue := convertAnalysisValue(category, subkeys, value)
+			insertIntoNestedMap(analysisData[category], subkeys, convertedValue)
+		}
+	}
+
+	if len(analysisData["analyzer"]) > 0 {
+		analyzerJSON, _ := json.Marshal(analysisData["analyzer"])
+		d.Set("analysis_analyzer", string(analyzerJSON))
+	}
+	if len(analysisData["tokenizer"]) > 0 {
+		tokenizerJSON, _ := json.Marshal(analysisData["tokenizer"])
+		d.Set("analysis_tokenizer", string(tokenizerJSON))
+	}
+	if len(analysisData["filter"]) > 0 {
+		filterJSON, _ := json.Marshal(analysisData["filter"])
+		d.Set("analysis_filter", string(filterJSON))
+	}
+	if len(analysisData["char_filter"]) > 0 {
+		charFilterJSON, _ := json.Marshal(analysisData["char_filter"])
+		d.Set("analysis_char_filter", string(charFilterJSON))
+	}
+	if len(analysisData["normalizer"]) > 0 {
+		normalizerJSON, _ := json.Marshal(analysisData["normalizer"])
+		d.Set("analysis_normalizer", string(normalizerJSON))
+	}
+
 	var response *json.RawMessage
 	var res *elastic7.Response
 	var mappingsResponse map[string]interface{}
@@ -847,6 +896,48 @@ func resourceOpensearchIndexRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	return nil
+}
+
+// convertAnalysisValue converts values from OpenSearch to the expected types in Terraform configuration
+func convertAnalysisValue(category string, keys []string, value interface{}) interface{} {
+	// For analysis configurations, we want to preserve the natural types
+	// that come back from OpenSearch (integers, booleans, strings)
+	
+	// For all cases, try to convert strings to their natural types
+	if str, ok := value.(string); ok {
+		// Try boolean conversion first
+		if str == "true" {
+			return true
+		}
+		if str == "false" {
+			return false
+		}
+		
+		// Try integer conversion
+		if intVal, err := strconv.Atoi(str); err == nil {
+			return intVal
+		}
+		
+		// Try float conversion
+		if floatVal, err := strconv.ParseFloat(str, 64); err == nil {
+			return floatVal
+		}
+	}
+	
+	return value
+}
+
+// This is used to rebuild nested analysis configuration (analyzers, tokenizers, filters, char_filters, normalizers)
+// from the flattened `index.analysis.*` keys returned by OpenSearch on import.
+func insertIntoNestedMap(m map[string]interface{}, keys []string, value interface{}) {
+	if len(keys) == 1 {
+		m[keys[0]] = value
+		return
+	}
+	if _, ok := m[keys[0]].(map[string]interface{}); !ok {
+		m[keys[0]] = map[string]interface{}{}
+	}
+	insertIntoNestedMap(m[keys[0]].(map[string]interface{}), keys[1:], value)
 }
 
 func updateAliases(index string, oldAliases, newAliases map[string]interface{}, meta interface{}) error {

--- a/provider/resource_opensearch_index_test.go
+++ b/provider/resource_opensearch_index_test.go
@@ -21,23 +21,6 @@ resource "opensearch_index" "test" {
 }
 `
 
-	testOpensearchIndexImport = `
-resource "opensearch_index" "test1import" {
-  name               = "terraform-test1import"
-  number_of_shards   = 1
-  number_of_replicas = 1
-  mappings = jsonencode(
-    {
-      "properties" : {
-        "name" : {
-          "type" : "text"
-        }
-      }
-    }
-  )
-}
-`
-
 	testAccOpensearchIndexUpdate1 = `
 resource "opensearch_index" "test" {
   name                                  = "terraform-test"
@@ -87,8 +70,8 @@ resource "opensearch_index" "test" {
   })
   analysis_tokenizer = jsonencode({
     custom_ngram_tokenizer = {
-      max_gram = "4"
-      min_gram = "3"
+      max_gram = 4
+      min_gram = 3
       type     = "ngram"
     }
   })
@@ -312,6 +295,68 @@ resource "opensearch_index" "test" {
   })
 
   depends_on = [opensearch_index_template.test]
+}
+`
+	testAccOpensearchIndexImportAnalysis = `
+resource "opensearch_index" "test_import_analysis" {
+  name = "terraform-test-import-analysis"
+  number_of_shards = 1
+  number_of_replicas = 1
+
+  analysis_analyzer = jsonencode({
+    custom_analyzer = {
+      type = "custom"
+      tokenizer = "standard"
+      filter = ["lowercase", "asciifolding"]
+    }
+  })
+
+  analysis_filter = jsonencode({
+    my_shingle_filter = {
+      type = "shingle"
+      max_shingle_size = 2
+      min_shingle_size = 2
+      output_unigrams = false
+    }
+  })
+
+  analysis_tokenizer = jsonencode({
+    my_ngram_tokenizer = {
+      type = "ngram"
+      min_gram = 3
+      max_gram = 4
+    }
+  })
+
+  analysis_char_filter = jsonencode({
+    my_char_filter_apostrophe = {
+      type = "mapping"
+      mappings = ["'=>"]
+    }
+  })
+
+  analysis_normalizer = jsonencode({
+    my_normalizer = {
+      type = "custom"
+      filter = ["lowercase", "asciifolding"]
+    }
+  })
+}
+`
+	testOpensearchIndexImport = `
+resource "opensearch_index" "test1import" {
+  name               = "terraform-test1import"
+  number_of_shards   = 1
+  number_of_replicas = 1
+  mappings = jsonencode(
+    {
+      "properties" : {
+        "name" : {
+          "type" : "text"
+        }
+      }
+    }
+  )
 }
 `
 )
@@ -733,6 +778,47 @@ func checkOpensearchIndexDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func TestAccOpensearchIndex_importAnalysis(t *testing.T) {
+	resourceName := "opensearch_index.test_import_analysis"
+	indexName := "terraform-test-import-analysis"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: checkOpensearchIndexDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create the index with analysis fields
+			{
+				Config: testAccOpensearchIndexImportAnalysis,
+				Check: resource.ComposeTestCheckFunc(
+					checkOpensearchIndexExists(resourceName),
+				),
+			},
+			// Step 2: Import the index
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     indexName,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy",
+				},
+			},
+			// Step 3: Re-run the same config and ensure no diffs appear
+			{
+				Config: testAccOpensearchIndexImportAnalysis,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "analysis_analyzer", `{"custom_analyzer":{"filter":["lowercase","asciifolding"],"tokenizer":"standard","type":"custom"}}`),
+					resource.TestCheckResourceAttr(resourceName, "analysis_filter", `{"my_shingle_filter":{"max_shingle_size":2,"min_shingle_size":2,"output_unigrams":false,"type":"shingle"}}`),
+					resource.TestCheckResourceAttr(resourceName, "analysis_tokenizer", `{"my_ngram_tokenizer":{"max_gram":4,"min_gram":3,"type":"ngram"}}`),
+					resource.TestCheckResourceAttr(resourceName, "analysis_char_filter", `{"my_char_filter_apostrophe":{"mappings":["'=\u003e"],"type":"mapping"}}`),
+					resource.TestCheckResourceAttr(resourceName, "analysis_normalizer", `{"my_normalizer":{"filter":["lowercase","asciifolding"],"type":"custom"}}`),
+				),
+			},
+		},
+	})
 }
 
 const testAccOpensearchIndexWithAlias = `


### PR DESCRIPTION
### Description
Previously analysis configuration (analyzers, tokenizers, filters, char_filters, normalizers) were not populated into Terraform state after import.


The [PR](https://github.com/opensearch-project/terraform-provider-opensearch/pull/227), by [gonz-cint](https://github.com/gonz-cint), was able to do this.  It converted flattened index.analysis.* keys returned by OpenSearch back into proper nested JSON structure so that users could see analysis settings after import.
It also tested that analysis configuration could be imported and reconstructed from flattened keys.

Unfortunately this PR has been stuck in draft since 2025.

This PR builds on that PR, however it extends it by using two features in combination:

- Adding enhanced type conversion, (using `convertAnalysisValue`function) to convert strings to natural types (i.e. numeric strings to integers, "true"/"false" strings to actual boolean values).  This maintains Opensearch data types (with fallback of original value if the "cascade" of conversion fails).
-  Followed by rebuilding arbitrary nesting depths/structures from the flattened Opensearch keys, (using `insertIntoNestedMap` recursive function), to handle nested maps in a more generic way.

It also adds type validation to the original PR testing: note that the Terraform config is converted to the JSON-escaped version of characters that Opensearch stores and returns.

I've also tested this by using the debug provider to create, and also to successfully import a test index into state (using an AWS Opensearch 2.17 cluster).


### Issues Resolved
This PR will close issues: 

[288](https://github.com/opensearch-project/terraform-provider-opensearch/issues/288) (my issue)
[255](https://github.com/opensearch-project/terraform-provider-opensearch/issues/2250) ([gonz-cint](https://github.com/gonz-cint)[gonz-cint](https://github.com/gonz-cint)'s original issue)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
