### PR TITLE
Fix OS_CLIENT_KEY_PATH and OS_CLIENT_CERTIFICATE_PATH env vars

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -173,14 +173,12 @@ func Provider() *schema.Provider {
 			"client_cert_path": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "",
 				Description: "A X509 certificate to connect to OpenSearch",
 				DefaultFunc: schema.EnvDefaultFunc("OS_CLIENT_CERTIFICATE_PATH", ""),
 			},
 			"client_key_path": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "",
 				Description: "A X509 key to connect to OpenSearch",
 				DefaultFunc: schema.EnvDefaultFunc("OS_CLIENT_KEY_PATH", ""),
 			},


### PR DESCRIPTION
As specified in the [schema definition](https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/schema/schema.go#L191-L192) `DefaultFunc` is not supported alongside `Default`, which in this case is always used instead, making it impossible to set the client certificate paths using the environment variables.