### PR TITLE
Create a TLS HTTP client even if only client certificates are set

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -342,7 +342,7 @@ func getClient(conf *ProviderConf) (*elastic7.Client, error) {
 			return nil, err
 		}
 		opts = append(opts, elastic7.SetHttpClient(client), elastic7.SetSniff(false))
-	} else if conf.insecure || conf.cacertFile != "" {
+	} else if conf.insecure || conf.cacertFile != "" || (conf.certPemPath != "" && conf.keyPemPath != "") {
 		opts = append(opts, elastic7.SetHttpClient(tlsHttpClient(conf, map[string]string{})), elastic7.SetSniff(false))
 		if conf.token != "" {
 			opts = append(opts, elastic7.SetHttpClient(tokenHttpClient(conf, map[string]string{})), elastic7.SetSniff(false))


### PR DESCRIPTION
If one secures the OpenSearch REST API with certificates signed by a known authority (i.e. Let's Encrypt) setting `insecure = true` or a CA certificate isn't required, since the provider will validate the server certificate against the CA store of the operating system. Currently, this causes the provider to ignore any provided client certificates since no TLS HTTP client is created.

This fixes this, using the client even if only the client certificates are provided.
