### PR TITLE
Add development sandbox to improve contributions confidence and testability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,14 @@
 /vendor
 .DS_Store
 .vscode/
+.idea/
 terraform-provider-opensearch
 __debug*
+
+# Developer sandbox
+.dev.terraformrc
+dev/terraform.tfvars
+dev/terraform.tfstate
+dev/terraform.tfstate.backup
+dev/.terraform/
+dev/.terraform.lock.hcl

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,95 @@
+.PHONY: docs up down test dev-up dev-down dev-build dev-config dev-plan dev-apply dev-destroy dev dev-teardown
+
+OSS_IMAGE ?= opensearchproject/opensearch:2
+OSS_DASHBOARDS_IMAGE ?=opensearchproject/opensearch-dashboards:2
+OPENSEARCH_INITIAL_ADMIN_PASSWORD ?= myStrongPassword123@456
+OPENSEARCH_URL ?= http://admin:myStrongPassword123%40456@localhost:9200
+DEV_TF_ENV = TF_CLI_CONFIG_FILE=$(CURDIR)/.dev.terraformrc
+
+# =============================================================================
+# Core targets — generate documentation and run acceptance tests against a
+# local OpenSearch cluster.
+#
+# Usage:
+#   make docs          # regenerate provider documentation (go generate)
+#   make up            # start OpenSearch cluster
+#   make down          # stop OpenSearch cluster
+#   make test          # start cluster + run acceptance tests (TF_ACC=1)
+# =============================================================================
+
+docs:
+	go generate ./...
+
+up:
+	@export OSS_IMAGE=$(OSS_IMAGE) && \
+	export OPENSEARCH_INITIAL_ADMIN_PASSWORD=$(OPENSEARCH_INITIAL_ADMIN_PASSWORD) && \
+	docker compose up -d
+
+down:
+	@docker compose down
+
+test: up
+	@export OPENSEARCH_URL=$(OPENSEARCH_URL) && \
+	export TF_LOG=INFO && \
+	TF_ACC=1 go test ./provider -v -parallel 20 -cover -short
+
+# =============================================================================
+# Developer sandbox — spin up a real cluster (with OpenSearch Dashboards), build
+# the provider from source, and apply a representative Terraform configuration
+# (dev/) to verify resources work end-to-end.
+#
+# Terraform variables are read from dev/terraform.tfvars (gitignored). Copy
+# dev/terraform.tfvars.example to get started.
+#
+# Usage:
+#   make dev           # full one-command setup: dev-up + wait + dev-apply
+#   make dev-up        # start OpenSearch cluster + Dashboards (compose `dashboards` profile)
+#   make dev-down      # stop OpenSearch cluster + Dashboards
+#   make dev-build     # build the provider binary in the repo root
+#   make dev-config    # write .dev.terraformrc with dev_overrides → local binary
+#   make dev-plan      # rebuild + preview changes (no apply) (cluster must already be up)
+#   make dev-apply     # rebuild + apply (cluster must already be up)
+#   make dev-destroy   # destroy Terraform resources (cluster stays up)
+#   make dev-teardown  # dev-destroy + stop OpenSearch cluster + Dashboards
+# =============================================================================
+
+dev-up:
+	@export OSS_IMAGE=$(OSS_IMAGE) && \
+	export OSS_DASHBOARDS_IMAGE=$(OSS_DASHBOARDS_IMAGE) && \
+	export OPENSEARCH_INITIAL_ADMIN_PASSWORD=$(OPENSEARCH_INITIAL_ADMIN_PASSWORD) && \
+	export COMPOSE_PROFILES=dashboards && \
+	docker compose up -d
+
+dev-down:
+	@export COMPOSE_PROFILES=dashboards && \
+	docker compose down
+
+dev-build:
+	@echo "Building provider binary..."
+	go build -o terraform-provider-opensearch .
+	@echo "Provider binary built."
+
+dev-config:
+	@echo "Generating .dev.terraformrc to enable Terraform to use locally-built binary..."
+	@printf 'provider_installation {\n  dev_overrides {\n    "opensearch-project/opensearch" = "%s"\n  }\n  direct {}\n}\n' "$(CURDIR)" > .dev.terraformrc
+	@echo "Generated .dev.terraformrc."
+
+dev-plan: dev-build dev-config
+	@echo "Running terraform plan..."
+	$(DEV_TF_ENV) terraform -chdir=dev plan
+
+dev-apply: dev-build dev-config
+	@echo "Running terraform apply with auto-approve..."
+	$(DEV_TF_ENV) terraform -chdir=dev apply -auto-approve
+
+dev-destroy:
+	@echo "Running terraform destroy with auto-approve..."
+	$(DEV_TF_ENV) terraform -chdir=dev destroy -auto-approve
+
+# Uses `dev-up` instead of `up` to activate the `dashboards` compose profile so OpenSearch Dashboards container is used.
+dev: dev-up
+	@echo "Waiting for OpenSearch to be ready (up to 120s)..."
+	./script/wait-for-endpoint --timeout=120 $(OPENSEARCH_URL)
+	$(MAKE) dev-apply
+
+dev-teardown: dev-destroy down

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
   - [Running tests locally](#running-tests-locally)
     - [To Run Specific Test](#to-run-specific-test)
     - [Fix the go-lint errors](#fix-the-go-lint-errors)
+  - [Developer sandbox](#developer-sandbox)
+  - [Generating documentation](#generating-documentation)
   - [Debugging this provider](#debugging-this-provider)
 - [Version and Branching](#version-and-branching)
 - [Contributing](#contributing)
@@ -42,6 +44,14 @@ Examples of resources can be found in the examples directory.
 
 ### Running tests locally
 
+The `Makefile` wraps the most common workflows. Running `make test` starts a local OpenSearch cluster (via Docker Compose) and executes the full acceptance-test suite:
+
+```sh
+make test
+```
+
+**Manual equivalent** (no `make`):
+
 ```sh
 export OSS_IMAGE="opensearchproject/opensearch:2"
 docker compose up -d
@@ -59,13 +69,68 @@ Note:  Starting from version `2.12.0`, the `admin` user password is determined b
 
 ```sh
 cd provider/
-TF_ACC=2 go test -run TestAccOpensearchOpenDistroDashboardTenant  -v -cover -short
+TF_ACC=2 go test -run TestAccOpensearchOpenDistroDashboardTenant -v -cover -short
 ```
 
 #### Fix the go-lint errors
 
 ```sh
-golangci-lint run --out-format=github-actions 
+golangci-lint run --out-format=github-actions
+```
+
+### Developer sandbox
+
+The `dev/` directory is a ready-to-use Terraform configuration that provisions a small set of resources against a locally-running cluster. 
+It is useful for iterating on provider changes end-to-end without writing temporary Terraform code.
+
+**One-command setup** (starts OpenSearch + Dashboards, builds the provider, and applies the sandbox config):
+
+```sh
+make dev
+```
+
+The images for OpenSearch core and OpenSearch Dashboards can be overridden; so can the initial admin password:
+
+```sh
+OSS_IMAGE=opensearchproject/opensearch:2.17.0 \
+OSS_DASHBOARDS_IMAGE=opensearchproject/opensearch-dashboards:2.17.0 \
+OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123@456 \
+make dev-up
+```
+
+To manage the cluster independently (without Dashboards):
+
+```sh
+make up    # start OpenSearch only
+make down  # stop OpenSearch
+```
+
+Available Make targets related to the development sandbox:
+
+| Target              | Description                                                                           |
+|---------------------|---------------------------------------------------------------------------------------|
+| `make dev-up`       | Start OpenSearch + OpenSearch Dashboards (`dashboards` Compose profile)               |
+| `make dev-build`    | Build the provider binary to use locally                                              |
+| `make dev-config`   | Generate `.dev.terraformrc` with a `dev_overrides` block pointing to the local binary |
+| `make dev-plan`     | Build + `terraform plan` against `dev/`                                               |
+| `make dev-apply`    | Build + `terraform apply -auto-approve` against `dev/`                                |
+| `make dev-destroy`  | `terraform destroy -auto-approve` (cluster stays up)                                  |
+| `make dev-teardown` | Destroy Terraform resources and stop the OpenSearch cluster + OpenSearch Dashboards   |
+| `make dev-down`     | Stop OpenSearch cluster + OpenSearch Dashboards without touching Terraform state      |
+
+**Terraform variables** are read from `dev/terraform.tfvars` (gitignored). Copy `dev/terraform.tfvars.example` to get started.
+The defaults work against the local Docker cluster with no changes needed. 
+For AWS-specific testing, pass credentials as `TF_VAR_*` environment variables — see `dev/terraform.tfvars.example`.
+
+The UI of OpenSearch Dashboards will be exposed at `http://localhost:5601` when the `dev-up` target is used.
+
+### Generating documentation
+
+Generate example usage documentation in `docs/` from the configuration in `resources/<resource name>/import.sh` and
+`resources/<resource name>/resource.tf`:
+
+```sh
+make docs
 ```
 
 ### Debugging this provider

--- a/dev/main.tf
+++ b/dev/main.tf
@@ -1,0 +1,36 @@
+# Security: User
+resource "opensearch_user" "user" {
+  username    = "dev-sandbox-user"
+  password    = "DevSandbox123!"
+  description = "Developer sandbox application user"
+}
+
+# Security: Role
+resource "opensearch_role" "role" {
+  role_name   = "dev-sandbox-reader"
+  description = "Read-only access to dev-sandbox indices"
+
+  index_permissions {
+    index_patterns  = ["dev-sandbox-*"]
+    allowed_actions = ["read", "get", "search", "indices:monitor/stats"]
+  }
+}
+
+# Security: Role Mapping
+resource "opensearch_roles_mapping" "role_mapping" {
+  role_name = opensearch_role.role.id
+  users     = [opensearch_user.user.id]
+}
+
+# Index
+resource "opensearch_index" "index" {
+  name               = "dev-sandbox-index"
+  number_of_shards   = "1"
+  number_of_replicas = "0"
+  mappings = jsonencode({
+    properties = {
+      timestamp = { type = "date" }
+      message   = { type = "text" }
+    }
+  })
+}

--- a/dev/terraform.tf
+++ b/dev/terraform.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    opensearch = {
+      source  = "opensearch-project/opensearch"
+      version = ">= 2.0.0"
+    }
+  }
+}
+
+provider "opensearch" {
+  url               = var.opensearch_url
+  healthcheck       = false
+  sign_aws_requests = var.sign_aws_requests
+}

--- a/dev/terraform.tfvars.example
+++ b/dev/terraform.tfvars.example
@@ -1,0 +1,24 @@
+# Copy this file to terraform.tfvars and uncomment the relevant block.
+# terraform.tfvars is gitignored so credentials stay local.
+
+# =============================================================================
+# Core variables
+# These values match the defaults — no terraform.tfvars needed
+# =============================================================================
+# opensearch_url    = "http://admin:myStrongPassword123%40456@localhost:9200"
+# sign_aws_requests = false
+
+# =============================================================================
+# AWS-related variables
+#
+# AWS credentials required by resources. Set these via TF_VAR_aws_<...> in the
+# environment where the make targets are running — see terraform.tfvars.example.
+# =============================================================================
+# `.tfvars` files don't interpolate env vars, so export them in your shell.
+# Example:
+#   TF_VAR_aws_access_key=$AWS_ACCESS_KEY_ID \
+#   TF_VAR_aws_secret_key=$AWS_SECRET_ACCESS_KEY \
+#   TF_VAR_aws_session_token=$AWS_SESSION_TOKEN \
+#   make dev-apply
+#
+# Or simply update `DEV_TF_ENV` in Makefile to set these environment variables.

--- a/dev/variables.tf
+++ b/dev/variables.tf
@@ -1,0 +1,41 @@
+# =============================================================================
+# Core variables
+# =============================================================================
+variable "opensearch_url" {
+  type        = string
+  description = "OpenSearch cluster URL. Defaults to the local Docker cluster."
+  default     = "http://admin:myStrongPassword123%40456@localhost:9200"
+}
+
+variable "sign_aws_requests" {
+  type        = bool
+  description = "Enable AWS SigV4 request signing for AWS OpenSearch Service."
+  default     = false
+}
+
+# =============================================================================
+# AWS-related variables
+#
+# AWS credentials required by resources. Set these via TF_VAR_aws_<...> in the
+# environment where the make targets are running — see terraform.tfvars.example.
+# =============================================================================
+variable "aws_access_key" {
+  type        = string
+  description = "AWS access key."
+  default     = ""
+  sensitive   = true
+}
+
+variable "aws_secret_key" {
+  type        = string
+  description = "AWS secret key."
+  default     = ""
+  sensitive   = true
+}
+
+variable "aws_session_token" {
+  type        = string
+  description = "AWS session token (for temporary credentials)."
+  default     = ""
+  sensitive   = true
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image:  ${OSS_IMAGE:-opensearchproject/opensearch:2}
     hostname: opensearch
     container_name: opensearch
-    networks: 
+    networks:
       - opensearch # used by OpenSearch Dashboard
     environment:
       - cluster.name=opensearch
@@ -27,6 +27,20 @@ services:
         hard: -1
     ports:
       - 9200:9200
+  opensearch-dashboards:
+    profiles:
+      - dashboards
+    image: ${OSS_DASHBOARDS_IMAGE:-opensearchproject/opensearch-dashboards:2}
+    container_name: opensearch-dashboards
+    hostname: opensearch-dashboards
+    networks:
+      - opensearch
+    ports:
+      - 5601:5601
+    environment:
+      - OPENSEARCH_HOSTS=http://opensearch:9200
+    depends_on:
+      - opensearch
 networks:
   opensearch:
     driver: bridge


### PR DESCRIPTION
### Description
- Add a development-only sandbox that can be used to easily
   - The goal is to increase the confidence of developers who want to contribute, since they can test the new / updated resources in a live cluster by using the locally-built provider as-is and validate those changes in the UI of OpenSearch Dashboards.
- Add Makefile with targets to test, generate documentation, control the lifecycle of locally-running OpenSearch core / OpenSearch Dashboards instances.
   - These Make targets make development easier by simplifying normal operations that should be done by every contributor.

### Issues Resolved
Closes https://github.com/opensearch-project/terraform-provider-opensearch/issues/299
[[FEATURE] Contribution - Add development sandbox to improve contributions confidence and testability
](https://github.com/opensearch-project/terraform-provider-opensearch/issues/299)


### Testing → ✅
- `make dev-up` successfully creates the OpenSearch core and OpenSearch Dashboards containers locally
   <img width="600" src="https://github.com/user-attachments/assets/6a302ca4-0bc4-43a1-832a-ba0fddebb52e" />
   <img width="600" src="https://github.com/user-attachments/assets/6b6ce019-82c3-4a1d-a8e8-14766940a601" />
- `make dev-apply` successfully creates the resources in the local OpenSearch cluster
   <img width="600" src="https://github.com/user-attachments/assets/f7439c3f-7ee5-430c-9bbb-3c80e4aac380" />
   <img width="600" src="https://github.com/user-attachments/assets/6349a91e-70a1-4b17-8871-8ebe5b998f74" />
- OpenSearch Dashboards is properly connected and shows the resources created
   <img width="600" src="https://github.com/user-attachments/assets/3e0e8402-b669-4e12-9b9d-df3e3d01e55d" />
   <img width="600" src="https://github.com/user-attachments/assets/42117f29-b04d-43f8-b80b-c990527e43ab" />

> [!Note]
I also used this to test my previous (still open) contribution of support for ML resources - https://github.com/opensearch-project/terraform-provider-opensearch/pull/280

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
