### PR TITLE
Add AssumeRoleWithWebIdentity support for EKS IRSA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Changed
 
 ### Added
+* Support for `AssumeRoleWithWebIdentity` via the new `aws_web_identity_role_arn` and `aws_web_identity_token_file` arguments, which default to the standard `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` environment variables so EKS IRSA works with no configuration ([#89](https://github.com/opensearch-project/terraform-provider-opensearch/issues/89))
 
 ### Fixed
 

--- a/docs/data-sources/host.md
+++ b/docs/data-sources/host.md
@@ -29,5 +29,3 @@ data "opensearch_host" "test" {
 
 - `id` (String) The ID of this resource.
 - `url` (String) the url of the active cluster
-
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,8 +75,8 @@ EOF
 - `aws_secret_key` (String) The secret key for use with AWS OpenSearch Service domains
 - `aws_signature_service` (String) AWS service name used in the credential scope of signed requests to OpenSearch.
 - `aws_token` (String) The session token for use with AWS OpenSearch Service domains
-- `aws_web_identity_role_arn` (String) Amazon Resource Name of an IAM Role to assume via AssumeRoleWithWebIdentity. Defaults to the standard AWS_ROLE_ARN environment variable, so EKS IRSA works with no configuration.
-- `aws_web_identity_token_file` (String) Path to a file containing an OIDC web identity token. Defaults to the standard AWS_WEB_IDENTITY_TOKEN_FILE environment variable, so EKS IRSA works with no configuration.
+- `aws_web_identity_role_arn` (String) Amazon Resource Name of an IAM Role to assume via AssumeRoleWithWebIdentity. Falls back to the standard AWS_ROLE_ARN environment variable (so EKS IRSA works with no configuration), unless an explicit aws_profile is set, in which case the environment variable is ignored — mirroring the AWS CLI.
+- `aws_web_identity_token_file` (String) Path to a file containing an OIDC web identity token. Falls back to the standard AWS_WEB_IDENTITY_TOKEN_FILE environment variable (so EKS IRSA works with no configuration), unless an explicit aws_profile is set, in which case the environment variable is ignored — mirroring the AWS CLI.
 - `cacert_file` (String) A Custom CA certificate
 - `client_cert_path` (String) A X509 certificate to connect to OpenSearch
 - `client_key_path` (String) A X509 key to connect to OpenSearch

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,11 +69,14 @@ EOF
 - `aws_access_key` (String) The access key for use with AWS OpenSearch Service domains
 - `aws_assume_role_arn` (String) Amazon Resource Name of an IAM Role to assume prior to making AWS API calls.
 - `aws_assume_role_external_id` (String) External ID configured in the IAM policy of the IAM Role to assume prior to making AWS API calls.
+- `aws_assume_role_session_name` (String) Session name to use when assuming a role, including via web identity.
 - `aws_profile` (String) The AWS profile for use with AWS OpenSearch Service domains
 - `aws_region` (String) The AWS region for use in signing of AWS OpenSearch requests. Must be specified in order to use AWS URL signing with AWS OpenSearch endpoint exposed on a custom DNS domain.
 - `aws_secret_key` (String) The secret key for use with AWS OpenSearch Service domains
 - `aws_signature_service` (String) AWS service name used in the credential scope of signed requests to OpenSearch.
 - `aws_token` (String) The session token for use with AWS OpenSearch Service domains
+- `aws_web_identity_role_arn` (String) Amazon Resource Name of an IAM Role to assume via AssumeRoleWithWebIdentity. Defaults to the standard AWS_ROLE_ARN environment variable, so EKS IRSA works with no configuration.
+- `aws_web_identity_token_file` (String) Path to a file containing an OIDC web identity token. Defaults to the standard AWS_WEB_IDENTITY_TOKEN_FILE environment variable, so EKS IRSA works with no configuration.
 - `cacert_file` (String) A Custom CA certificate
 - `client_cert_path` (String) A X509 certificate to connect to OpenSearch
 - `client_key_path` (String) A X509 key to connect to OpenSearch
@@ -98,6 +101,7 @@ The provider is flexible in the means of providing credentials for authenticatio
 
 - Static credentials
 - Assume role configuration
+- Web identity (IRSA)
 - Environment variables
 - Shared credentials file
 
@@ -150,6 +154,33 @@ provider "opensearch" {
   aws_assume_role_external_id = "SecretID"
 }
 ```
+
+#### Web identity (IRSA)
+
+If your workload runs with a web identity token (for example, EKS IAM Roles for Service Accounts), the provider will assume the role via `AssumeRoleWithWebIdentity`. On EKS this works with **no configuration**: `aws_web_identity_role_arn` and `aws_web_identity_token_file` default to the standard `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` environment variables that the pod's service account injects.
+
+You can also configure it explicitly:
+
+```tf
+provider "opensearch" {
+  url                         = "https://search-foo-bar-pqrhr4w3u4dzervg41frow4mmy.us-east-1.es.amazonaws.com"
+  aws_web_identity_role_arn   = "arn:aws:iam::012345678901:role/rolename"
+  aws_web_identity_token_file = "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
+}
+```
+
+This is independent of `aws_assume_role_arn`. If you set both, the web identity credentials are resolved first and then used to assume `aws_assume_role_arn` (role chaining):
+
+```tf
+provider "opensearch" {
+  url                         = "https://search-foo-bar-pqrhr4w3u4dzervg41frow4mmy.us-east-1.es.amazonaws.com"
+  aws_web_identity_role_arn   = "arn:aws:iam::012345678901:role/irsa-role"
+  aws_web_identity_token_file = "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
+  aws_assume_role_arn         = "arn:aws:iam::012345678901:role/target-role"
+}
+```
+
+Setting `aws_profile` suppresses the `AWS_ROLE_ARN` / `AWS_WEB_IDENTITY_TOKEN_FILE` environment variable defaults, so the named profile is used instead of ambient IRSA credentials. This mirrors the AWS CLI (botocore) `disable_env_vars` behaviour. Web identity set explicitly via `aws_web_identity_role_arn` / `aws_web_identity_token_file` still applies even when a profile is configured.
 
 #### Environment variables
 

--- a/docs/resources/anomaly_detection.md
+++ b/docs/resources/anomaly_detection.md
@@ -78,5 +78,3 @@ EOF
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-
-

--- a/docs/resources/audit_config.md
+++ b/docs/resources/audit_config.md
@@ -123,6 +123,8 @@ Required:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Import by name
 terraform import opensearch_audit_config.test_config my-config

--- a/docs/resources/channel_configuration.md
+++ b/docs/resources/channel_configuration.md
@@ -47,6 +47,8 @@ EOF
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import opensearch_channel_configuration.configuration_1 configuration_1
 ```

--- a/docs/resources/component_template.md
+++ b/docs/resources/component_template.md
@@ -59,6 +59,8 @@ EOF
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Import by name
 terraform import opensearch_component_template.test terraform-test

--- a/docs/resources/composable_index_template.md
+++ b/docs/resources/composable_index_template.md
@@ -62,6 +62,8 @@ EOF
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import opensearch_composable_index_template.template_1 template_1
 ```

--- a/docs/resources/dashboard_object.md
+++ b/docs/resources/dashboard_object.md
@@ -111,5 +111,3 @@ EOF
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-
-

--- a/docs/resources/dashboard_tenant.md
+++ b/docs/resources/dashboard_tenant.md
@@ -40,6 +40,8 @@ resource "opensearch_dashboard_tenant" "test" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import opensearch_dashboard_tenant.writer test
 ```

--- a/docs/resources/data_stream.md
+++ b/docs/resources/data_stream.md
@@ -39,5 +39,3 @@ resource "opensearch_data_stream" "foo" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-
-

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -130,6 +130,8 @@ resource "opensearch_index" "index" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Import by name
 terraform import opensearch_index.test terraform-test

--- a/docs/resources/index_template.md
+++ b/docs/resources/index_template.md
@@ -64,6 +64,8 @@ EOF
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import opensearch_index_template.template_1 template_1
 ```

--- a/docs/resources/ingest_pipeline.md
+++ b/docs/resources/ingest_pipeline.md
@@ -49,6 +49,8 @@ EOF
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import opensearch_ingest_pipeline.test terraform-test
 ```

--- a/docs/resources/ism_policy.md
+++ b/docs/resources/ism_policy.md
@@ -41,6 +41,8 @@ resource "opensearch_ism_policy" "cleanup" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import opensearch_ism_policy.cleanup delete_after_15d
 ```

--- a/docs/resources/ism_policy_mapping.md
+++ b/docs/resources/ism_policy_mapping.md
@@ -55,6 +55,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 # Import by poilcy_id
 terraform import opensearch_ism_policy_mapping.test policy_1

--- a/docs/resources/ml_connector.md
+++ b/docs/resources/ml_connector.md
@@ -204,7 +204,7 @@ resource "opensearch_ml_connector" "with_client_config" {
 ### Required
 
 - `actions` (Block List, Min: 1) Defines the actions that can run within the connector (see [below for nested schema](#nestedblock--actions))
-- `credential` (Map of String) Defines any credential variables required for connecting to the endpoint
+- `credential` (Map of String, Sensitive) Defines any credential variables required for connecting to the endpoint
 - `description` (String) Description of the ML Connector
 - `name` (String) Name of the ML Connector
 - `parameters` (Map of String) The default ML Connector parameters, including `endpoint`, `model`, and `skip_validating_missing_parameters`. Any parameters indicated in this field can be overridden by parameters specified in a PREDICT request.

--- a/docs/resources/ml_model.md
+++ b/docs/resources/ml_model.md
@@ -198,9 +198,11 @@ resource "opensearch_ml_model" "third_party_with_model_guardrails" {
 - `model_config` (Block List, Max: 1) Model’s configuration, including the `model_type`, `embedding_dimension`, and `framework_type`. The optional `all_config` JSON string contains all model configurations. The `additional_config` object contains the corresponding `space_type` for pretrained models or the specified `space_type` for custom models. Required for custom models. (see [below for nested schema](#nestedblock--model_config))
 - `model_content_hash_value` (String) SHA-256 hash of the downloaded model. Required for custom models.
 - `model_format` (String) Portable format of the model file. Valid values are `"TORCH_SCRIPT"` and `"ONNX"`. Required for OS-provided pretrained and custom models)
+- `predict_probe_body` (String) JSON body sent to `POST /_plugins/_ml/models/<id>/_predict` when probing readiness. Defaults to `{"parameters": {"inputText": "healthcheck"}}`, which works for remote connector models. Override this for models whose predict API expects a different input format (e.g. `{"text_docs": ["healthcheck"]}`). Only takes effect when `wait_for_predict = true`.
 - `rate_limiter` (Block List, Max: 1) Limits the number of times that any user can call the Predict API on the ML Model. (see [below for nested schema](#nestedblock--rate_limiter))
 - `url` (String) URL from which to download the model. Required for custom models.
 - `version` (String) Version of the ML Model. For OS-provided models, this identifies which version to download.
+- `wait_for_predict` (Boolean) When true (default), polls `POST /_plugins/_ml/models/<id>/_predict` after deployment to confirm the model is actually usable in memory — not just `DEPLOYED` in the index. Only takes effect when `deploy_after_registering = true`. Set to false to rely only on `model_state`.
 
 ### Read-Only
 

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -99,6 +99,8 @@ EOF
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import opensearch_monitor.alert lgOZb3UB96pyyRQv0ppQ
 ```

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -87,6 +87,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import opensearch_role.writer logs_writer
 ```

--- a/docs/resources/roles_mapping.md
+++ b/docs/resources/roles_mapping.md
@@ -47,6 +47,8 @@ resource "opensearch_roles_mapping" "mapper" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import opensearch_roles_mapping.mapper logs_writer
 ```

--- a/docs/resources/script.md
+++ b/docs/resources/script.md
@@ -41,6 +41,8 @@ resource "opensearch_script" "test_script" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import opensearch_script.test_script my_script
 ```

--- a/docs/resources/sm_policy.md
+++ b/docs/resources/sm_policy.md
@@ -93,6 +93,8 @@ resource "opensearch_sm_policy" "snapshot_to_s3" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import opensearch_sm_policy.cleanup snapshot_to_s3
 ```

--- a/docs/resources/snapshot_repository.md
+++ b/docs/resources/snapshot_repository.md
@@ -45,6 +45,8 @@ resource "opensearch_snapshot_repository" "repo" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import opensearch_snapshot_repository.repo es-index-backups
 ```

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -66,6 +66,8 @@ resource "opensearch_roles_mapping" "reader" {
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import opensearch_user.reader app_reader
 ```

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -623,11 +623,6 @@ func assumeRoleCredentials(region, roleARN, roleExternalID, roleSessionName, pro
 		assumeRoleProvider.ExternalID = aws.String(roleExternalID)
 	}
 
-	// Apply the session name to the plain assume-role path, not just the web
-	// identity path, matching the AWS CLI (botocore AssumeRoleProvider maps
-	// role_session_name / AWS_ROLE_SESSION_NAME to RoleSessionName):
-	//   https://github.com/boto/botocore/blob/d6092247/botocore/credentials.py#L1643-L1645
-	//   https://github.com/boto/botocore/blob/d6092247/botocore/credentials.py#L1884
 	if roleSessionName != "" {
 		assumeRoleProvider.RoleSessionName = roleSessionName
 	}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -43,31 +43,34 @@ var awsOpensearchServerlessUrlRegexp = regexp.MustCompile(`([a-z0-9-]+).aoss.ama
 var minimalOpensearchServerlessVersion = "2.0.0"
 
 type ProviderConf struct {
-	rawUrl                  string
-	insecure                bool
-	sniffing                bool
-	healthchecking          bool
-	cacertFile              string
-	username                string
-	password                string
-	token                   string
-	tokenName               string
-	parsedUrl               *url.URL
-	signAWSRequests         bool
-	osVersion               string
-	pingTimeoutSeconds      int
-	awsRegion               string
-	awsAssumeRoleArn        string
-	awsAssumeRoleExternalID string
-	awsAccessKeyId          string
-	awsSecretAccessKey      string
-	awsSessionToken         string
-	awsSig4Service          string
-	awsProfile              string
-	certPemPath             string
-	keyPemPath              string
-	hostOverride            string
-	proxy                   string
+	rawUrl                   string
+	insecure                 bool
+	sniffing                 bool
+	healthchecking           bool
+	cacertFile               string
+	username                 string
+	password                 string
+	token                    string
+	tokenName                string
+	parsedUrl                *url.URL
+	signAWSRequests          bool
+	osVersion                string
+	pingTimeoutSeconds       int
+	awsRegion                string
+	awsAssumeRoleArn         string
+	awsAssumeRoleExternalID  string
+	awsAssumeRoleSessionName string
+	awsWebIdentityRoleArn    string
+	awsWebIdentityTokenFile  string
+	awsAccessKeyId           string
+	awsSecretAccessKey       string
+	awsSessionToken          string
+	awsSig4Service           string
+	awsProfile               string
+	certPemPath              string
+	keyPemPath               string
+	hostOverride             string
+	proxy                    string
 	// determined after connecting to the server
 	flavor ServerFlavor
 
@@ -131,6 +134,24 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				Default:     "",
 				Description: "External ID configured in the IAM policy of the IAM Role to assume prior to making AWS API calls.",
+			},
+			"aws_assume_role_session_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("AWS_ROLE_SESSION_NAME", ""),
+				Description: "Session name to use when assuming a role, including via web identity.",
+			},
+			"aws_web_identity_role_arn": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: "Amazon Resource Name of an IAM Role to assume via AssumeRoleWithWebIdentity. Falls back to the standard AWS_ROLE_ARN environment variable (so EKS IRSA works with no configuration), unless an explicit aws_profile is set, in which case the environment variable is ignored — mirroring the AWS CLI.",
+			},
+			"aws_web_identity_token_file": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: "Path to a file containing an OIDC web identity token. Falls back to the standard AWS_WEB_IDENTITY_TOKEN_FILE environment variable (so EKS IRSA works with no configuration), unless an explicit aws_profile is set, in which case the environment variable is ignored — mirroring the AWS CLI.",
 			},
 			"aws_access_key": {
 				Type:        schema.TypeString,
@@ -287,16 +308,19 @@ func providerConfigure(c context.Context, d *schema.ResourceData) (interface{}, 
 		pingTimeoutSeconds: d.Get("version_ping_timeout").(int),
 		awsRegion:          d.Get("aws_region").(string),
 
-		awsAssumeRoleArn:        d.Get("aws_assume_role_arn").(string),
-		awsAssumeRoleExternalID: d.Get("aws_assume_role_external_id").(string),
-		awsAccessKeyId:          d.Get("aws_access_key").(string),
-		awsSecretAccessKey:      d.Get("aws_secret_key").(string),
-		awsSessionToken:         d.Get("aws_token").(string),
-		awsProfile:              d.Get("aws_profile").(string),
-		certPemPath:             d.Get("client_cert_path").(string),
-		keyPemPath:              d.Get("client_key_path").(string),
-		hostOverride:            d.Get("host_override").(string),
-		proxy:                   d.Get("proxy").(string),
+		awsAssumeRoleArn:         d.Get("aws_assume_role_arn").(string),
+		awsAssumeRoleExternalID:  d.Get("aws_assume_role_external_id").(string),
+		awsAssumeRoleSessionName: d.Get("aws_assume_role_session_name").(string),
+		awsWebIdentityRoleArn:    d.Get("aws_web_identity_role_arn").(string),
+		awsWebIdentityTokenFile:  d.Get("aws_web_identity_token_file").(string),
+		awsAccessKeyId:           d.Get("aws_access_key").(string),
+		awsSecretAccessKey:       d.Get("aws_secret_key").(string),
+		awsSessionToken:          d.Get("aws_token").(string),
+		awsProfile:               d.Get("aws_profile").(string),
+		certPemPath:              d.Get("client_cert_path").(string),
+		keyPemPath:               d.Get("client_key_path").(string),
+		hostOverride:             d.Get("host_override").(string),
+		proxy:                    d.Get("proxy").(string),
 	}
 
 	osClient, err := getOSClient(conf)
@@ -305,7 +329,66 @@ func providerConfigure(c context.Context, d *schema.ResourceData) (interface{}, 
 	}
 	conf.osClient = osClient
 
-	return conf, nil
+	resolveAWSWebIdentityEnv(conf)
+
+	return conf, awsCredentialWarnings(conf)
+}
+
+// resolveAWSWebIdentityEnv applies the standard web identity environment
+// variables (AWS_ROLE_ARN, AWS_WEB_IDENTITY_TOKEN_FILE) to the provider
+// configuration so that EKS IRSA works with no explicit configuration.
+//
+// It mirrors the AWS CLI (botocore) credential precedence: an explicitly
+// configured profile suppresses web identity sourced from the environment, so
+// an explicit aws_profile wins over ambient IRSA env vars. Web identity set
+// explicitly in the provider config is left untouched and still applies.
+//
+// This matches botocore at commit d6092247:
+//   - create_credential_resolver derives disable_env_vars from whether a profile
+//     was explicitly selected:
+//     https://github.com/boto/botocore/blob/d6092247/botocore/credentials.py#L84-L95
+//   - AssumeRoleWithWebIdentityProvider._get_env_config returns None for
+//     AWS_ROLE_ARN / AWS_WEB_IDENTITY_TOKEN_FILE when env vars are disabled, i.e.
+//     when a profile was explicitly selected:
+//     https://github.com/boto/botocore/blob/d6092247/botocore/credentials.py#L1918-L1924
+func resolveAWSWebIdentityEnv(conf *ProviderConf) {
+	// An explicit profile disables env-var-sourced web identity (botocore's
+	// disable_env_vars). aws_access_key is not checked here because static keys
+	// already take unconditional precedence in awsSession.
+	if conf.awsProfile != "" {
+		return
+	}
+	if conf.awsWebIdentityRoleArn == "" {
+		conf.awsWebIdentityRoleArn = os.Getenv("AWS_ROLE_ARN")
+	}
+	if conf.awsWebIdentityTokenFile == "" {
+		conf.awsWebIdentityTokenFile = os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE")
+	}
+}
+
+// awsCredentialWarnings surfaces likely-misconfiguration diagnostics for the AWS
+// credential settings. Assuming a role via web identity requires both a role ARN
+// and a token file; with only one set the web identity source is silently
+// skipped, so we warn to make the misconfiguration explicit.
+//
+// The AWS CLI goes further and errors in the token-set-but-role-missing case
+// (botocore AssumeRoleWithWebIdentityProvider._assume_role_with_web_identity at
+// commit d6092247:
+// https://github.com/boto/botocore/blob/d6092247/botocore/credentials.py#L1944-L1953);
+// we prefer a warning over a hard failure for both partial cases.
+func awsCredentialWarnings(conf *ProviderConf) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if (conf.awsWebIdentityRoleArn == "") != (conf.awsWebIdentityTokenFile == "") {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "Incomplete web identity configuration",
+			Detail: "Only one of aws_web_identity_role_arn (or AWS_ROLE_ARN) and " +
+				"aws_web_identity_token_file (or AWS_WEB_IDENTITY_TOKEN_FILE) is set. " +
+				"Both are required to assume a role via AssumeRoleWithWebIdentity (e.g. EKS IRSA); " +
+				"the web identity credential source will be skipped.",
+		})
+	}
+	return diags
 }
 
 func getOSClient(conf *ProviderConf) (*opensearch.Client, error) {
@@ -517,10 +600,16 @@ func getClient(conf *ProviderConf) (*elastic7.Client, error) {
 	return client, nil
 }
 
-func assumeRoleCredentials(region, roleARN, roleExternalID, profile string, endpoint string) *awscredentials.Credentials {
+func assumeRoleCredentials(region, roleARN, roleExternalID, roleSessionName, profile string, endpoint string, base *awscredentials.Credentials) *awscredentials.Credentials {
 	sessOpts := awsSessionOptions(region, endpoint)
 	if profile != "" {
 		sessOpts.Profile = profile
+	}
+	// When base credentials are supplied (e.g. resolved via web identity), sign
+	// the STS AssumeRole call with them so the role is chained from that
+	// identity rather than the ambient credential chain.
+	if base != nil {
+		sessOpts.Config.Credentials = base
 	}
 
 	sess := awssession.Must(awssession.NewSessionWithOptions(sessOpts))
@@ -534,7 +623,25 @@ func assumeRoleCredentials(region, roleARN, roleExternalID, profile string, endp
 		assumeRoleProvider.ExternalID = aws.String(roleExternalID)
 	}
 
+	// Apply the session name to the plain assume-role path, not just the web
+	// identity path, matching the AWS CLI (botocore AssumeRoleProvider maps
+	// role_session_name / AWS_ROLE_SESSION_NAME to RoleSessionName):
+	//   https://github.com/boto/botocore/blob/d6092247/botocore/credentials.py#L1643-L1645
+	//   https://github.com/boto/botocore/blob/d6092247/botocore/credentials.py#L1884
+	if roleSessionName != "" {
+		assumeRoleProvider.RoleSessionName = roleSessionName
+	}
+
 	return awscredentials.NewChainCredentials([]awscredentials.Provider{assumeRoleProvider})
+}
+
+func assumeRoleWithWebIdentityCredentials(region, roleARN, sessionName, tokenFile, endpoint string) *awscredentials.Credentials {
+	sessOpts := awsSessionOptions(region, endpoint)
+	sess := awssession.Must(awssession.NewSessionWithOptions(sessOpts))
+	stsClient := awssts.New(sess)
+	provider := awsstscreds.NewWebIdentityRoleProviderWithOptions(stsClient, roleARN, sessionName, awsstscreds.FetchTokenPath(tokenFile))
+
+	return awscredentials.NewChainCredentials([]awscredentials.Provider{provider})
 }
 
 func awsSessionOptions(region string, endpoint string) awssession.Options {
@@ -562,18 +669,30 @@ func awsSession(region string, conf *ProviderConf, endpoint string) *awssession.
 	sessOpts := awsSessionOptions(region, endpoint)
 
 	// 1. access keys take priority
-	// 2. next is an assume role configuration
-	// 3. followed by a profile (for assume role)
-	// 4. let the default credentials provider figure out the rest (env, ec2, etc..)
+	// 2. next is an explicit assume role configuration. If web identity is also
+	//    configured, its credentials are resolved first and used as the base for
+	//    the assume-role call (role chaining); otherwise the base session uses
+	//    the standard credential chain, which also resolves IRSA env vars.
+	// 3. next is an assume role via web identity (e.g. EKS IRSA). The role ARN
+	//    and token file come from aws_web_identity_role_arn / aws_web_identity_token_file,
+	//    which resolveAWSWebIdentityEnv() has already populated from AWS_ROLE_ARN /
+	//    AWS_WEB_IDENTITY_TOKEN_FILE unless an explicit aws_profile suppressed them
+	//    (matching the AWS CLI). So env-sourced web identity yields to an explicit
+	//    profile (case 4), while explicitly-configured web identity still wins here.
+	// 4. followed by a profile (for assume role)
+	// 5. let the default credentials provider figure out the rest (env, ec2, etc..)
 	//
 	// note: if #1 is chosen, then no further providers will be tested, since we've overridden the credentials with just a static provider
 	if conf.awsAccessKeyId != "" {
 		sessOpts.Config.Credentials = awscredentials.NewStaticCredentials(conf.awsAccessKeyId, conf.awsSecretAccessKey, conf.awsSessionToken)
 	} else if conf.awsAssumeRoleArn != "" {
-		if conf.awsAssumeRoleExternalID == "" {
-			conf.awsAssumeRoleExternalID = ""
+		var base *awscredentials.Credentials
+		if conf.awsWebIdentityTokenFile != "" && conf.awsWebIdentityRoleArn != "" {
+			base = assumeRoleWithWebIdentityCredentials(region, conf.awsWebIdentityRoleArn, conf.awsAssumeRoleSessionName, conf.awsWebIdentityTokenFile, endpoint)
 		}
-		sessOpts.Config.Credentials = assumeRoleCredentials(region, conf.awsAssumeRoleArn, conf.awsAssumeRoleExternalID, conf.awsProfile, endpoint)
+		sessOpts.Config.Credentials = assumeRoleCredentials(region, conf.awsAssumeRoleArn, conf.awsAssumeRoleExternalID, conf.awsAssumeRoleSessionName, conf.awsProfile, endpoint, base)
+	} else if conf.awsWebIdentityTokenFile != "" && conf.awsWebIdentityRoleArn != "" {
+		sessOpts.Config.Credentials = assumeRoleWithWebIdentityCredentials(region, conf.awsWebIdentityRoleArn, conf.awsAssumeRoleSessionName, conf.awsWebIdentityTokenFile, endpoint)
 	} else if conf.awsProfile != "" {
 		sessOpts.Profile = conf.awsProfile
 	}

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -245,6 +245,101 @@ func TestAWSCredsAssumeRole(t *testing.T) {
 }
 
 // Given:
+// 1. AWS credentials are specified via environment variables
+// 2. An AWS role ARN and a session name are specified via the provider configuration
+//
+// This tests that: the configured session name is applied to the plain
+// AssumeRole call (not just the web identity path), matching the AWS CLI.
+func TestAWSCredsAssumeRoleSessionName(t *testing.T) {
+	envAccessKeyID := "ENV_ACCESS_KEY"
+	testRegion := "us-east-1"
+	assumeRoleArn := "arn:aws:iam::123456789012:role/demo/TestAR"
+	assumeRoleSessionName := "my-session-name"
+	assumeRoleAccessKeyID := "ASIAIOSFODNN7EXAMPLE"
+
+	os.Setenv("AWS_ACCESS_KEY_ID", envAccessKeyID)
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "ENV_SECRET")
+
+	server := mockServer{
+		ResponseFixturePath:     "./test-fixtures/api_assume_role_response.xml",
+		ExpectedAccessKeyId:     envAccessKeyID,
+		ExpectedRoleArn:         assumeRoleArn,
+		ExpectedRoleSessionName: assumeRoleSessionName,
+	}
+
+	server.Start(t)
+	defer server.Stop()
+
+	testConfig := &ProviderConf{
+		awsAssumeRoleArn:         assumeRoleArn,
+		awsAssumeRoleSessionName: assumeRoleSessionName,
+	}
+
+	creds := getCreds(t, testRegion, testConfig, server.Endpoint)
+
+	if creds.AccessKeyID != assumeRoleAccessKeyID {
+		t.Errorf("access key id should have been %s (we got %s)", assumeRoleAccessKeyID, creds.AccessKeyID)
+	}
+
+	os.Unsetenv("AWS_ACCESS_KEY_ID")
+	os.Unsetenv("AWS_SECRET_ACCESS_KEY")
+}
+
+// Given:
+// 1. Only one of the web identity role ARN / token file is configured
+//
+// This tests that: awsCredentialWarnings emits a warning for the partial web
+// identity configuration, and stays silent when both or neither are set.
+func TestAWSCredsWebIdentityPartialConfigWarning(t *testing.T) {
+	cases := []struct {
+		name        string
+		conf        *ProviderConf
+		wantWarning bool
+	}{
+		{
+			name:        "only role arn",
+			conf:        &ProviderConf{awsWebIdentityRoleArn: "arn:aws:iam::123456789012:role/demo/TestWebIdentity"},
+			wantWarning: true,
+		},
+		{
+			name:        "only token file",
+			conf:        &ProviderConf{awsWebIdentityTokenFile: "./test-fixtures/web_identity_token"},
+			wantWarning: true,
+		},
+		{
+			name: "both set",
+			conf: &ProviderConf{
+				awsWebIdentityRoleArn:   "arn:aws:iam::123456789012:role/demo/TestWebIdentity",
+				awsWebIdentityTokenFile: "./test-fixtures/web_identity_token",
+			},
+			wantWarning: false,
+		},
+		{
+			name:        "neither set",
+			conf:        &ProviderConf{},
+			wantWarning: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			diags := awsCredentialWarnings(tc.conf)
+			if tc.wantWarning && !diags.HasError() && len(diags) == 0 {
+				t.Errorf("expected a warning diagnostic, got none")
+			}
+			if !tc.wantWarning && len(diags) != 0 {
+				t.Errorf("expected no diagnostics, got %v", diags)
+			}
+			if tc.wantWarning {
+				if len(diags) != 1 || diags[0].Severity != diag.Warning {
+					t.Errorf("expected exactly one warning diagnostic, got %v", diags)
+				}
+			}
+		})
+	}
+}
+
+// Given:
 // 1. An AWS profile, role ARN and External ID are specified via the provider configuration
 //
 // This tests that: we can get the credentials after having assumed the given role from the specified profile.
@@ -322,6 +417,191 @@ func TestAWSCredsAssumeRoleFromDefaultProfile(t *testing.T) {
 	os.Unsetenv("AWS_SHARED_CREDENTIALS_FILE")
 }
 
+// Given:
+// 1. A web identity role ARN and token file are specified via the provider configuration
+//
+// This tests that: we assume the role via AssumeRoleWithWebIdentity using the token file.
+func TestAWSCredsAssumeRoleWithWebIdentity(t *testing.T) {
+	testRegion := "us-east-1"
+	webIdentityRoleArn := "arn:aws:iam::123456789012:role/demo/TestWebIdentity"
+	webIdentityAccessKeyID := "ASIAWEBIDENTITYEXAMPLE"
+
+	server := mockServer{
+		ResponseFixturePath:      "./test-fixtures/api_assume_role_with_web_identity_response.xml",
+		ExpectedRoleArn:          webIdentityRoleArn,
+		ExpectedWebIdentityToken: readTokenFixture(t, "./test-fixtures/web_identity_token"),
+	}
+
+	server.Start(t)
+	defer server.Stop()
+
+	testConfig := &ProviderConf{
+		awsWebIdentityRoleArn:   webIdentityRoleArn,
+		awsWebIdentityTokenFile: "./test-fixtures/web_identity_token",
+	}
+
+	creds := getCreds(t, testRegion, testConfig, server.Endpoint)
+
+	if creds.AccessKeyID != webIdentityAccessKeyID {
+		t.Errorf("access key id should have been %s (we got %s)", webIdentityAccessKeyID, creds.AccessKeyID)
+	}
+}
+
+// Given:
+// 1. AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE are set via environment variables (as EKS IRSA injects them)
+// 2. No AWS configuration is provided to the provider
+//
+// This tests that: the web identity provider args default from the standard AWS
+// environment variables, so IRSA autodiscovery works with no configuration.
+func TestAWSCredsWebIdentityAutodiscovery(t *testing.T) {
+	testRegion := "us-east-1"
+	webIdentityRoleArn := "arn:aws:iam::123456789012:role/demo/TestWebIdentity"
+	webIdentityAccessKeyID := "ASIAWEBIDENTITYEXAMPLE"
+
+	server := mockServer{
+		ResponseFixturePath:      "./test-fixtures/api_assume_role_with_web_identity_response.xml",
+		ExpectedRoleArn:          webIdentityRoleArn,
+		ExpectedWebIdentityToken: readTokenFixture(t, "./test-fixtures/web_identity_token"),
+	}
+
+	server.Start(t)
+	defer server.Stop()
+
+	os.Setenv("AWS_ROLE_ARN", webIdentityRoleArn)
+	os.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "./test-fixtures/web_identity_token")
+
+	// With no explicit web identity configuration, resolveAWSWebIdentityEnv
+	// populates the fields from the standard AWS_ROLE_ARN /
+	// AWS_WEB_IDENTITY_TOKEN_FILE env vars, exactly as it does at runtime.
+	testConfig := &ProviderConf{}
+	resolveAWSWebIdentityEnv(testConfig)
+
+	creds := getCreds(t, testRegion, testConfig, server.Endpoint)
+
+	if creds.AccessKeyID != webIdentityAccessKeyID {
+		t.Errorf("access key id should have been %s (we got %s)", webIdentityAccessKeyID, creds.AccessKeyID)
+	}
+
+	os.Unsetenv("AWS_ROLE_ARN")
+	os.Unsetenv("AWS_WEB_IDENTITY_TOKEN_FILE")
+}
+
+// Given:
+// 1. AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE are set via environment variables
+// 2. An explicit aws_profile is configured
+//
+// This tests that: the explicit profile suppresses the env-sourced web identity,
+// mirroring the AWS CLI (botocore) disable_env_vars rule. resolveAWSWebIdentityEnv
+// must leave the web identity fields empty so the profile credentials are used.
+func TestAWSCredsWebIdentityEnvSuppressedByProfile(t *testing.T) {
+	webIdentityRoleArn := "arn:aws:iam::123456789012:role/demo/TestWebIdentity"
+
+	os.Setenv("AWS_ROLE_ARN", webIdentityRoleArn)
+	os.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "./test-fixtures/web_identity_token")
+
+	testConfig := &ProviderConf{
+		awsProfile: "testing",
+	}
+	resolveAWSWebIdentityEnv(testConfig)
+
+	if testConfig.awsWebIdentityRoleArn != "" {
+		t.Errorf("expected web identity role arn to be suppressed by explicit profile, got %s", testConfig.awsWebIdentityRoleArn)
+	}
+	if testConfig.awsWebIdentityTokenFile != "" {
+		t.Errorf("expected web identity token file to be suppressed by explicit profile, got %s", testConfig.awsWebIdentityTokenFile)
+	}
+
+	os.Unsetenv("AWS_ROLE_ARN")
+	os.Unsetenv("AWS_WEB_IDENTITY_TOKEN_FILE")
+}
+
+// Given:
+// 1. A web identity role ARN and token file are configured
+// 2. aws_assume_role_arn is also configured
+//
+// This tests that: the web identity credentials are resolved first and then
+// used to sign the AssumeRole call for the second role (role chaining). We
+// assert on the ordering of STS actions and that the second call is signed with
+// the access key returned by the first (web identity) call.
+func TestAWSCredsWebIdentityChainedToAssumeRole(t *testing.T) {
+	testRegion := "us-east-1"
+	webIdentityRoleArn := "arn:aws:iam::123456789012:role/demo/TestWebIdentity"
+	chainedRoleArn := "arn:aws:iam::123456789012:role/demo/TestChainedRole"
+	webIdentityAccessKeyID := "ASIAWEBIDENTITYEXAMPLE"
+	chainedAccessKeyID := "ASIACHAINEDROLEEXAMPLE"
+	expectedToken := readTokenFixture(t, "./test-fixtures/web_identity_token")
+
+	var actions []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Error while parsing form: %v", err)
+		}
+		action := r.PostForm.Get("Action")
+		actions = append(actions, action)
+
+		var fixture string
+		switch action {
+		case "AssumeRoleWithWebIdentity":
+			if r.PostForm.Get("RoleArn") != webIdentityRoleArn {
+				t.Errorf("web identity call: expected RoleArn %s, got %s", webIdentityRoleArn, r.PostForm.Get("RoleArn"))
+			}
+			if r.PostForm.Get("WebIdentityToken") != expectedToken {
+				t.Errorf("web identity call: expected token %s, got %s", expectedToken, r.PostForm.Get("WebIdentityToken"))
+			}
+			fixture = "./test-fixtures/api_assume_role_with_web_identity_response.xml"
+		case "AssumeRole":
+			if r.PostForm.Get("RoleArn") != chainedRoleArn {
+				t.Errorf("assume role call: expected RoleArn %s, got %s", chainedRoleArn, r.PostForm.Get("RoleArn"))
+			}
+			// The chained AssumeRole call must be signed with the web identity
+			// credentials, not the ambient environment. Verify the SigV4
+			// Authorization header carries the web identity access key.
+			auth := r.Header.Get("Authorization")
+			if !strings.Contains(auth, webIdentityAccessKeyID) {
+				t.Errorf("assume role call should be signed with web identity key %s, authorization header was %s", webIdentityAccessKeyID, auth)
+			}
+			fixture = "./test-fixtures/api_chained_assume_role_response.xml"
+		default:
+			t.Errorf("unexpected STS action: %s", action)
+			return
+		}
+
+		response, err := os.ReadFile(fixture)
+		if err != nil {
+			t.Errorf("Error while reading mockResponse %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		if _, err = w.Write(response); err != nil {
+			t.Errorf("Error while writing mock server response %v", err)
+		}
+	}))
+	defer server.Close()
+
+	testConfig := &ProviderConf{
+		awsAssumeRoleArn:        chainedRoleArn,
+		awsWebIdentityRoleArn:   webIdentityRoleArn,
+		awsWebIdentityTokenFile: "./test-fixtures/web_identity_token",
+	}
+
+	creds := getCreds(t, testRegion, testConfig, server.URL)
+
+	if creds.AccessKeyID != chainedAccessKeyID {
+		t.Errorf("access key id should have been %s (we got %s)", chainedAccessKeyID, creds.AccessKeyID)
+	}
+
+	if len(actions) != 2 || actions[0] != "AssumeRoleWithWebIdentity" || actions[1] != "AssumeRole" {
+		t.Errorf("expected STS actions [AssumeRoleWithWebIdentity AssumeRole], got %v", actions)
+	}
+}
+
+func readTokenFixture(t *testing.T, path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed reading token fixture %s: %v", path, err)
+	}
+	return string(data)
+}
+
 func getCreds(t *testing.T, region string, config *ProviderConf, endpoint string) credentials.Value {
 	s := awsSession(region, config, endpoint)
 	if s == nil {
@@ -363,20 +643,24 @@ func TestAWSSocksProxy(t *testing.T) {
 }
 
 type mockServer struct {
-	ResponseFixturePath string
-	ExpectedAccessKeyId string
-	ExpectedRoleArn     string
-	ExpectedExternalId  string
-	Endpoint            string
-	server              *httptest.Server
+	ResponseFixturePath      string
+	ExpectedAccessKeyId      string
+	ExpectedRoleArn          string
+	ExpectedExternalId       string
+	ExpectedWebIdentityToken string
+	ExpectedRoleSessionName  string
+	Endpoint                 string
+	server                   *httptest.Server
 }
 
 func (s *mockServer) Start(t *testing.T) {
 	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
-		auth := r.Header.Get("Authorization")
-		if !strings.Contains(auth, s.ExpectedAccessKeyId) {
-			t.Errorf("Could not find expected access key id %s in authorization header %s", s.ExpectedAccessKeyId, auth)
+		if s.ExpectedAccessKeyId != "" {
+			auth := r.Header.Get("Authorization")
+			if !strings.Contains(auth, s.ExpectedAccessKeyId) {
+				t.Errorf("Could not find expected access key id %s in authorization header %s", s.ExpectedAccessKeyId, auth)
+			}
 		}
 
 		err := r.ParseForm()
@@ -388,8 +672,16 @@ func (s *mockServer) Start(t *testing.T) {
 			t.Errorf("expected RoleArn to be equal to %s, but got %s", s.ExpectedRoleArn, r.PostForm.Get("RoleArn"))
 		}
 
-		if r.PostForm.Get("ExternalId") != s.ExpectedExternalId {
+		if s.ExpectedExternalId != "" && r.PostForm.Get("ExternalId") != s.ExpectedExternalId {
 			t.Errorf("expected ExternalId to be equal to %s, but got %s", s.ExpectedExternalId, r.PostForm.Get("ExternalId"))
+		}
+
+		if s.ExpectedWebIdentityToken != "" && r.PostForm.Get("WebIdentityToken") != s.ExpectedWebIdentityToken {
+			t.Errorf("expected WebIdentityToken to be equal to %s, but got %s", s.ExpectedWebIdentityToken, r.PostForm.Get("WebIdentityToken"))
+		}
+
+		if s.ExpectedRoleSessionName != "" && r.PostForm.Get("RoleSessionName") != s.ExpectedRoleSessionName {
+			t.Errorf("expected RoleSessionName to be equal to %s, but got %s", s.ExpectedRoleSessionName, r.PostForm.Get("RoleSessionName"))
 		}
 
 		response, err := os.ReadFile(s.ResponseFixturePath)

--- a/provider/test-fixtures/api_assume_role_with_web_identity_response.xml
+++ b/provider/test-fixtures/api_assume_role_with_web_identity_response.xml
@@ -1,0 +1,20 @@
+<AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+	<AssumeRoleWithWebIdentityResult>
+		<SubjectFromWebIdentityToken>system:serviceaccount:default:opensearch</SubjectFromWebIdentityToken>
+		<Audience>sts.amazonaws.com</Audience>
+		<AssumedRoleUser>
+			<Arn>arn:aws:sts::123456789012:assumed-role/demo/TestWebIdentity</Arn>
+			<AssumedRoleId>ARO123EXAMPLE123:TestWebIdentity</AssumedRoleId>
+		</AssumedRoleUser>
+		<Credentials>
+			<AccessKeyId>ASIAWEBIDENTITYEXAMPLE</AccessKeyId>
+			<SecretAccessKey>wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY</SecretAccessKey>
+			<SessionToken>AQoDYXdzEPT//////////wEXAMPLEtc764bNrC9SAPBSM22wDOk4x4HIZ8j4FZTwdQWLWsKWHGBuFqwAeMicRXmxfpSPfIeoIYRqTflfKD8YUuwthAx7mSEI/qkPpKPi/kMcGd</SessionToken>
+			<Expiration>2019-11-09T13:34:41Z</Expiration>
+		</Credentials>
+		<Provider>arn:aws:iam::123456789012:oidc-provider/oidc.eks.example</Provider>
+	</AssumeRoleWithWebIdentityResult>
+	<ResponseMetadata>
+		<RequestId>ad4156e9-bce1-11e2-82e6-6b6efEXAMPLE</RequestId>
+	</ResponseMetadata>
+</AssumeRoleWithWebIdentityResponse>

--- a/provider/test-fixtures/api_chained_assume_role_response.xml
+++ b/provider/test-fixtures/api_chained_assume_role_response.xml
@@ -1,0 +1,21 @@
+<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+	<AssumeRoleResult>
+		<AssumedRoleUser>
+			<Arn>arn:aws:sts::123456789012:assumed-role/demo/TestChainedRole</Arn>
+			<AssumedRoleId>ARO123EXAMPLE123:TestChainedRole</AssumedRoleId>
+		</AssumedRoleUser>
+		<Credentials>
+			<AccessKeyId>ASIACHAINEDROLEEXAMPLE</AccessKeyId>
+			<SecretAccessKey>wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY</SecretAccessKey>
+			<SessionToken>
+				AQoDYXdzEPT//////////wEXAMPLEtc764bNrC9SAPBSM22wDOk4x4HIZ8j4FZTwdQW
+				LWsKWHGBuFqwAeMicRXmxfpSPfIeoIYRqTflfKD8YUuwthAx7mSEI/qkPpKPi/kMcGd
+			</SessionToken>
+			<Expiration>2019-11-09T13:34:41Z</Expiration>
+		</Credentials>
+		<PackedPolicySize>6</PackedPolicySize>
+	</AssumeRoleResult>
+	<ResponseMetadata>
+		<RequestId>c6104cbe-af31-11e0-8154-cbc7ccf896c7</RequestId>
+	</ResponseMetadata>
+</AssumeRoleResponse>

--- a/provider/test-fixtures/web_identity_token
+++ b/provider/test-fixtures/web_identity_token
@@ -1,0 +1,1 @@
+eyJhbGciOiJSUzI1NiIsImtpZCI6ImV4YW1wbGUifQ.eyJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpvcGVuc2VhcmNoIn0.example-signature

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -29,6 +29,7 @@ The provider is flexible in the means of providing credentials for authenticatio
 
 - Static credentials
 - Assume role configuration
+- Web identity (IRSA)
 - Environment variables
 - Shared credentials file
 
@@ -81,6 +82,33 @@ provider "opensearch" {
   aws_assume_role_external_id = "SecretID"
 }
 ```
+
+#### Web identity (IRSA)
+
+If your workload runs with a web identity token (for example, EKS IAM Roles for Service Accounts), the provider will assume the role via `AssumeRoleWithWebIdentity`. On EKS this works with **no configuration**: `aws_web_identity_role_arn` and `aws_web_identity_token_file` default to the standard `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` environment variables that the pod's service account injects.
+
+You can also configure it explicitly:
+
+```tf
+provider "opensearch" {
+  url                         = "https://search-foo-bar-pqrhr4w3u4dzervg41frow4mmy.us-east-1.es.amazonaws.com"
+  aws_web_identity_role_arn   = "arn:aws:iam::012345678901:role/rolename"
+  aws_web_identity_token_file = "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
+}
+```
+
+This is independent of `aws_assume_role_arn`. If you set both, the web identity credentials are resolved first and then used to assume `aws_assume_role_arn` (role chaining):
+
+```tf
+provider "opensearch" {
+  url                         = "https://search-foo-bar-pqrhr4w3u4dzervg41frow4mmy.us-east-1.es.amazonaws.com"
+  aws_web_identity_role_arn   = "arn:aws:iam::012345678901:role/irsa-role"
+  aws_web_identity_token_file = "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
+  aws_assume_role_arn         = "arn:aws:iam::012345678901:role/target-role"
+}
+```
+
+Setting `aws_profile` suppresses the `AWS_ROLE_ARN` / `AWS_WEB_IDENTITY_TOKEN_FILE` environment variable defaults, so the named profile is used instead of ambient IRSA credentials. This mirrors the AWS CLI (botocore) `disable_env_vars` behaviour. Web identity set explicitly via `aws_web_identity_role_arn` / `aws_web_identity_token_file` still applies even when a profile is configured.
 
 #### Environment variables
 


### PR DESCRIPTION
### Description
_Describe what this change achieves._

Adds two provider arguments, `aws_web_identity_role_arn` and `aws_web_identity_token_file`, that default to the standard `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` environment variables. On EKS this means IRSA credentials are discovered automatically with no provider configuration, resolving the access-denied failure when neither static credentials nor a profile are provided.

Setting `aws_web_identity_role_arn` and  `aws_assume_role_arn` chains the identities: the web identity credentials are resolved first and then used to sign the AssumeRole call for aws_assume_role_arn.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

Closes #89

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
