### PR TITLE
Add support for search.cancel_after_time_interval cluster setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Changed
 
 ### Added
+* Support the `search.cancel_after_time_interval` persistent cluster setting via `search_cancel_after_time_interval` on `opensearch_cluster_settings`
 
 ### Fixed
 

--- a/docs/resources/cluster_settings.md
+++ b/docs/resources/cluster_settings.md
@@ -69,6 +69,7 @@ resource "opensearch_cluster_settings" "global" {
 - `network_breaker_inflight_requests_overhead` (Number) A constant that all in flight requests estimations are multiplied by
 - `reset_settings_on_delete` (Boolean) If true, cluster settings will be reset to defaults when this resource is deleted
 - `script_max_compilations_rate` (String) Limit for the number of unique dynamic scripts within a certain interval that are allowed to be compiled, expressed as compilations divided by a time string
+- `search_cancel_after_time_interval` (String) A time string setting the default timeout for all search requests at the coordinating node level, after which the request is cancelled; defaults to -1 (no timeout)
 - `search_default_search_timeout` (String) A time string setting a cluster-wide default timeout for all search requests
 
 ### Read-Only

--- a/provider/resource_opensearch_cluster_settings.go
+++ b/provider/resource_opensearch_cluster_settings.go
@@ -33,6 +33,7 @@ var (
 		"network.breaker.inflight_requests.limit",
 		"script.max_compilations_rate",
 		"search.default_search_timeout",
+		"search.cancel_after_time_interval",
 		"action.auto_create_index",
 		"cluster.routing.allocation.enable",
 		"cluster.search.request.slowlog.level",
@@ -305,6 +306,11 @@ func resourceOpensearchClusterSettings() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "A time string setting a cluster-wide default timeout for all search requests",
+			},
+			"search_cancel_after_time_interval": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A time string setting the default timeout for all search requests at the coordinating node level, after which the request is cancelled; defaults to -1 (no timeout)",
 			},
 			"action_auto_create_index": {
 				Type:         schema.TypeString,

--- a/provider/resource_opensearch_cluster_settings_test.go
+++ b/provider/resource_opensearch_cluster_settings_test.go
@@ -43,6 +43,23 @@ func TestAccOpensearchClusterSettingsSlowLogs(t *testing.T) {
 	})
 }
 
+func TestAccOpensearchClusterSettingsCancelAfterTimeInterval(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: checkOpensearchClusterSettingsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpensearchClusterSettingsCancelAfterTimeInterval,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckOpensearchClusterSettingInState("opensearch_cluster_settings.global"),
+					testCheckOpensearchClusterSettingExists("search.cancel_after_time_interval"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccOpensearchClusterSettingsTypeList(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -130,6 +147,13 @@ resource "opensearch_cluster_settings" "global" {
   reset_settings_on_delete                      = true
   cluster_search_request_slowlog_level          = "WARN"
   cluster_search_request_slowlog_threshold_warn = "10s"
+}
+`
+
+var testAccOpensearchClusterSettingsCancelAfterTimeInterval = `
+resource "opensearch_cluster_settings" "global" {
+  reset_settings_on_delete          = true
+  search_cancel_after_time_interval = "10s"
 }
 `
 


### PR DESCRIPTION
### Description

Adds support for managing the persistent [`search.cancel_after_time_interval`](https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/search-settings/) cluster setting through the `opensearch_cluster_settings` resource via a new `search_cancel_after_time_interval` attribute.

This is a dynamic, cluster-level setting that sets the default timeout for all search requests at the coordinating node level. After the interval elapses, the request is stopped and all associated tasks are cancelled. It defaults to `-1` (no timeout). The value is a time string (e.g. `"10s"`), so the attribute is modeled as a `String`, consistent with the existing `search_default_search_timeout` attribute.

### Changes

- Register `search.cancel_after_time_interval` in `stringClusterSettings` and add the `search_cancel_after_time_interval` schema attribute (`provider/resource_opensearch_cluster_settings.go`).
- Add an acceptance test (`TestAccOpensearchClusterSettingsCancelAfterTimeInterval`).
- Regenerate resource documentation (`docs/resources/cluster_settings.md`).
- Add a CHANGELOG entry.

### Testing

Ran the acceptance tests against a local OpenSearch 2.x cluster (`docker compose up` + `TF_ACC=1`):

```
--- PASS: TestAccOpensearchClusterSettings (1.45s)
--- PASS: TestAccOpensearchClusterSettingsSlowLogs (1.13s)
--- PASS: TestAccOpensearchClusterSettingsCancelAfterTimeInterval (1.17s)
--- PASS: TestAccOpensearchClusterSettingsTypeList (1.20s)
PASS
```

`go build ./...`, `go vet ./provider/`, and `golangci-lint run ./provider/...` (0 issues) all pass.

### Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)