### PR TITLE
Propose moving @rblcoder to Emeritus status

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @peterzhuamazon @prudhvigodithi @jackson-theisen @phillbaker @rblcoder
+* @peterzhuamazon @prudhvigodithi @jackson-theisen @phillbaker

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,4 +10,10 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Prudhvi Godithi | [prudhvigodithi](https://github.com/prudhvigodithi)   | Amazon               |
 | jackson Theisen | [jackson-theisen](https://github.com/jackson-theisen) | External contributor  |
 | Phillip Baker   | [phillbaker](https://github.com/phillbaker)           | External contributor |
-| Rupa Lahiri   | [rblcoder](https://github.com/rblcoder)           | External contributor |
+
+
+## Emeritus
+
+| Maintainer         | GitHub ID                               |
+| --------------- | -------------------------------------------|
+| Rupa Lahiri   | [rblcoder](https://github.com/rblcoder)      |


### PR DESCRIPTION
Hey @rblcoder , we see you haven't used your maintainer privileges in the [past year](https://metrics.opensearch.org/_dashboards/app/dashboards?security_tenant=global#/view/30fedc30-9ae2-11ef-a168-f19b1bbc360c?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-30d,to:now))&_a=(description:'Shows%20data%20about%20the%20activity%20of%20maintainers%20in%20the%20OpenSearch%20Project(since%2010-12-24,%20and%20the%20technical-steering%20repo%20since%2011-7-24).%20',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!t,title:'OpenSearch%20Maintainer%20Dashboard',viewMode:view)) for this repo. 

If you plan on continuing to contribute, please respond here and close this PR. Otherwise, per our [inactivity policy](https://github.com/opensearch-project/technical-steering/blob/main/policies/RESPONSIBILITIES.md#inactivity) you'll be moved to emeritus, but you can move back to active status at any time.