### PR TITLE
Add rafamlr as maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @peterzhuamazon @prudhvigodithi @jackson-theisen @phillbaker
+* @peterzhuamazon @prudhvigodithi @jackson-theisen @phillbaker @rafamlr

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,7 +10,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Prudhvi Godithi | [prudhvigodithi](https://github.com/prudhvigodithi)   | Amazon               |
 | jackson Theisen | [jackson-theisen](https://github.com/jackson-theisen) | External contributor  |
 | Phillip Baker   | [phillbaker](https://github.com/phillbaker)           | External contributor |
-
+| Rafael Ribeiro  | [rafamlr](https://github.com/rafamlr)                 | Nexthink             |
 
 ## Emeritus
 


### PR DESCRIPTION
Note - this should not be merged until https://github.com/opensearch-project/.github/issues/606 is complete.

Following the [nomination process](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#becoming-a-maintainer), I have nominated and other maintainers have agreed to add Rafael Ribeiro (https://github.com/rafamlr) as a maintainer of the OpenSearch Terraform Provider repository. He has graciously accepted the invitation.

Rafael has authored 3 feature-request issues, merged 3 PRs, and provided reviews on PRs from other contributors in the repository. He has been actively contributing since January 2026, and his work spans new resource support, contributor tooling/testability, dependency and security hygiene, and code reviews for the community — a well-rounded profile across features, maintenance, and collaboration.

LFX insights: [Link](https://insights.linuxfoundation.org/project/opensearch-foundation/repository/opensearch-project_terraform-provider-opensearch/contributors?timeRange=past365days&start=2025-07-27&end=2026-07-27&widget=contributors-leaderboard)

Some of his key highlights:

 New Resource Support (ML)
- Added support for ML Connector, ML Model Group, and ML Model resources — a substantial, multi-resource feature delivery expanding the provider's coverage of OpenSearch machine-learning capabilities:  https://github.com/opensearch-project/terraform-provider-opensearch/pull/280

Contributor Experience & Testability
- Added a development sandbox to improve contribution confidence and testability, lowering the barrier for new contributors and improving the local development loop: https://github.com/opensearch-project/terraform-provider-opensearch/pull/298
  
Maintenance, Security & Build Hygiene
- Updated Go to 1.25, upgraded vulnerable dependencies, updated golangci/golangci-lint, and fixed the resulting linter issues — keeping the provider current and secure: https://github.com/opensearch-project/terraform-provider-opensearch/pull/302

Design Proposals / Feature Requests (issues)
- Support for ML resources — ML Connector, ML Model Group, ML Model: https://github.com/opensearch-project/terraform-provider-opensearch/issues/281
- Contribution — Add development sandbox to improve contributions confidence and testability: https://github.com/opensearch-project/terraform-provider-opensearch/issues/299
- Release v2.4.0 OpenSearch Terraform Provider: https://github.com/opensearch-project/terraform-provider-opensearch/issues/309

PR reviews (contributions from others):
 - https://github.com/opensearch-project/terraform-provider-opensearch/pull/310 (AssumeRoleWithWebIdentity support for EKS IRSA)
 - https://github.com/opensearch-project/terraform-provider-opensearch/pull/307 (Dashboards Workspaces management) 
 - https://github.com/opensearch-project/terraform-provider-opensearch/pull/297 (Fix permanent diff in dashboard index patterns)

His contributions across new resource support, contributor tooling, security/dependency hygiene, and consistent review activity for community PRs make him a strong candidate for a Terraform Provider OpenSearch maintainer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
