### PR TITLE
Add dashboard import support with tenant/index scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Support for `AssumeRoleWithWebIdentity` via the new `aws_web_identity_role_arn` and `aws_web_identity_token_file` arguments, which default to the standard `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` environment variables so EKS IRSA works with no configuration ([#89](https://github.com/opensearch-project/terraform-provider-opensearch/issues/89))
 
 ### Fixed
+* `opensearch_dashboard_object` no longer reports a diff when an index pattern's per-field popularity counters (`fields[].count`) are the only thing that changed. Dashboards increments them whenever someone uses a field in Discover, which made every managed index pattern drift continuously.
 
 ## [1.0.0] - 2023-04-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Support for `AssumeRoleWithWebIdentity` via the new `aws_web_identity_role_arn` and `aws_web_identity_token_file` arguments, which default to the standard `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` environment variables so EKS IRSA works with no configuration ([#89](https://github.com/opensearch-project/terraform-provider-opensearch/issues/89))
 
 ### Fixed
-* `opensearch_dashboard_object` no longer reports a diff when an index pattern's per-field popularity counters (`fields[].count`) are the only thing that changed. Dashboards increments them whenever someone uses a field in Discover, which made every managed index pattern drift continuously.
+* `opensearch_dashboard_object` no longer reports a diff when the only changes are bookkeeping Dashboards maintains itself: `updated_at`, and an index pattern's per-field popularity counters (`fields[].count`). Using Dashboards is enough to change both — the saved objects API restamps `updated_at` on every write, and Discover increments a counter whenever someone uses a field — which made managed objects drift continuously.
 
 ## [1.0.0] - 2023-04-15
 ### Added

--- a/docs/resources/dashboard_object.md
+++ b/docs/resources/dashboard_object.md
@@ -3,12 +3,12 @@
 page_title: "opensearch_dashboard_object Resource - terraform-provider-opensearch"
 subcategory: ""
 description: |-
-  Provides an OpenSearch Dashboards object resource. This resource interacts directly with the underlying OpenSearch index backing Dashboards, so the format must match what Dashboards the version of Dashboards is expecting. Dashboards with older versions - directly pulling the JSON from a Dashboards index of the same version of OpenSearch targeted by the provider is a workaround. For index patterns, per-field popularity counters (`fields[].count`) are ignored when diffing: Dashboards increments them as people use fields in Discover, so they are usage telemetry rather than configuration.
+  Provides an OpenSearch Dashboards object resource. This resource interacts directly with the underlying OpenSearch index backing Dashboards, so the format must match what Dashboards the version of Dashboards is expecting. Dashboards with older versions - directly pulling the JSON from a Dashboards index of the same version of OpenSearch targeted by the provider is a workaround. Bookkeeping Dashboards maintains itself is ignored when diffing: `updated_at`, which the saved objects API restamps on every write, and an index pattern's per-field popularity counters (`fields[].count`), which Dashboards increments as people use fields in Discover.
 ---
 
 # opensearch_dashboard_object (Resource)
 
-Provides an OpenSearch Dashboards object resource. This resource interacts directly with the underlying OpenSearch index backing Dashboards, so the format must match what Dashboards the version of Dashboards is expecting. Dashboards with older versions - directly pulling the JSON from a Dashboards index of the same version of OpenSearch targeted by the provider is a workaround. For index patterns, per-field popularity counters (`fields[].count`) are ignored when diffing: Dashboards increments them as people use fields in Discover, so they are usage telemetry rather than configuration.
+Provides an OpenSearch Dashboards object resource. This resource interacts directly with the underlying OpenSearch index backing Dashboards, so the format must match what Dashboards the version of Dashboards is expecting. Dashboards with older versions - directly pulling the JSON from a Dashboards index of the same version of OpenSearch targeted by the provider is a workaround. Bookkeeping Dashboards maintains itself is ignored when diffing: `updated_at`, which the saved objects API restamps on every write, and an index pattern's per-field popularity counters (`fields[].count`), which Dashboards increments as people use fields in Discover.
 
 ## Example Usage
 

--- a/docs/resources/dashboard_object.md
+++ b/docs/resources/dashboard_object.md
@@ -3,12 +3,12 @@
 page_title: "opensearch_dashboard_object Resource - terraform-provider-opensearch"
 subcategory: ""
 description: |-
-  Provides an OpenSearch Dashboards object resource. This resource interacts directly with the underlying OpenSearch index backing Dashboards, so the format must match what Dashboards the version of Dashboards is expecting. Dashboards with older versions - directly pulling the JSON from a Dashboards index of the same version of OpenSearch targeted by the provider is a workaround.
+  Provides an OpenSearch Dashboards object resource. This resource interacts directly with the underlying OpenSearch index backing Dashboards, so the format must match what Dashboards the version of Dashboards is expecting. Dashboards with older versions - directly pulling the JSON from a Dashboards index of the same version of OpenSearch targeted by the provider is a workaround. For index patterns, per-field popularity counters (`fields[].count`) are ignored when diffing: Dashboards increments them as people use fields in Discover, so they are usage telemetry rather than configuration.
 ---
 
 # opensearch_dashboard_object (Resource)
 
-Provides an OpenSearch Dashboards object resource. This resource interacts directly with the underlying OpenSearch index backing Dashboards, so the format must match what Dashboards the version of Dashboards is expecting. Dashboards with older versions - directly pulling the JSON from a Dashboards index of the same version of OpenSearch targeted by the provider is a workaround.
+Provides an OpenSearch Dashboards object resource. This resource interacts directly with the underlying OpenSearch index backing Dashboards, so the format must match what Dashboards the version of Dashboards is expecting. Dashboards with older versions - directly pulling the JSON from a Dashboards index of the same version of OpenSearch targeted by the provider is a workaround. For index patterns, per-field popularity counters (`fields[].count`) are ignored when diffing: Dashboards increments them as people use fields in Discover, so they are usage telemetry rather than configuration.
 
 ## Example Usage
 

--- a/docs/resources/dashboard_object.md
+++ b/docs/resources/dashboard_object.md
@@ -111,3 +111,20 @@ EOF
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+# Import from default (.kibana/global) scope
+terraform import opensearch_dashboard_object.test_visualization response-time-percentile
+
+# Import from a tenant scope
+terraform import opensearch_dashboard_object.test_visualization 'response-time-percentile,tenant_name=tenant_test'
+
+# Import from a custom Dashboards index
+terraform import opensearch_dashboard_object.test_visualization 'response-time-percentile,index=.kibana_custom'
+```

--- a/provider/resource_opensearch_dashboard_object.go
+++ b/provider/resource_opensearch_dashboard_object.go
@@ -20,7 +20,7 @@ const (
 
 func resourceOpensearchDashboardObject() *schema.Resource {
 	return &schema.Resource{
-		Description: "Provides an OpenSearch Dashboards object resource. This resource interacts directly with the underlying OpenSearch index backing Dashboards, so the format must match what Dashboards the version of Dashboards is expecting. Dashboards with older versions - directly pulling the JSON from a Dashboards index of the same version of OpenSearch targeted by the provider is a workaround.",
+		Description: "Provides an OpenSearch Dashboards object resource. This resource interacts directly with the underlying OpenSearch index backing Dashboards, so the format must match what Dashboards the version of Dashboards is expecting. Dashboards with older versions - directly pulling the JSON from a Dashboards index of the same version of OpenSearch targeted by the provider is a workaround. For index patterns, per-field popularity counters (`fields[].count`) are ignored when diffing: Dashboards increments them as people use fields in Discover, so they are usage telemetry rather than configuration.",
 		Create:      resourceOpensearchDashboardObjectCreate,
 		Read:        resourceOpensearchDashboardObjectRead,
 		Update:      resourceOpensearchDashboardObjectUpdate,
@@ -82,7 +82,8 @@ func resourceOpensearchDashboardObject() *schema.Resource {
 				StateFunc: func(v interface{}) string {
 					return normalizeDashboardObjectForState(v)
 				},
-				Description: "The JSON body of the dashboard object.",
+				DiffSuppressFunc: dashboardObjectPopularityDiffSuppress,
+				Description:      "The JSON body of the dashboard object.",
 			},
 			"tenant_name": {
 				Type:          schema.TypeString,
@@ -102,6 +103,89 @@ func resourceOpensearchDashboardObject() *schema.Resource {
 			},
 		},
 	}
+}
+
+// Dashboards increments an index pattern's per-field popularity counter every time someone
+// uses that field in Discover, writing it back into the saved object. It is usage telemetry
+// rather than configuration, so a difference confined to those counters is not drift worth
+// reporting: reverting them would only churn the document and they would climb again.
+func dashboardObjectPopularityDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	oldStripped, err := stripDashboardFieldPopularity(old)
+	if err != nil {
+		return false
+	}
+	newStripped, err := stripDashboardFieldPopularity(new)
+	if err != nil {
+		return false
+	}
+	return oldStripped == newStripped
+}
+
+// stripDashboardFieldPopularity returns body with every index pattern's `count` field removed,
+// canonicalised so two bodies differing only in those counters compare equal. Anything that
+// does not parse as the expected shape is left untouched rather than dropped, so an unexpected
+// document still diffs on its real contents.
+func stripDashboardFieldPopularity(body string) (string, error) {
+	var objects []interface{}
+	if err := json.Unmarshal([]byte(body), &objects); err != nil {
+		return "", err
+	}
+
+	for _, o := range objects {
+		object, ok := o.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		source, ok := object["_source"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		objectType, ok := source["type"].(string)
+		if !ok || objectType != "index-pattern" {
+			continue
+		}
+		attributes, ok := source[objectType].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		// Attributes hold `fields` as a JSON-encoded string, not a nested array.
+		encodedFields, ok := attributes["fields"].(string)
+		if !ok {
+			continue
+		}
+		var fields []interface{}
+		if err := json.Unmarshal([]byte(encodedFields), &fields); err != nil {
+			continue
+		}
+
+		stripped := false
+		for _, f := range fields {
+			field, ok := f.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if _, ok := field["count"]; ok {
+				delete(field, "count")
+				stripped = true
+			}
+		}
+		if !stripped {
+			continue
+		}
+
+		reencoded, err := json.Marshal(fields)
+		if err != nil {
+			continue
+		}
+		attributes["fields"] = string(reencoded)
+	}
+
+	// json.Marshal sorts object keys, so the result is canonical.
+	canonical, err := json.Marshal(objects)
+	if err != nil {
+		return "", err
+	}
+	return string(canonical), nil
 }
 
 func resourceOpensearchDashboardObjectImport(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {

--- a/provider/resource_opensearch_dashboard_object.go
+++ b/provider/resource_opensearch_dashboard_object.go
@@ -20,7 +20,7 @@ const (
 
 func resourceOpensearchDashboardObject() *schema.Resource {
 	return &schema.Resource{
-		Description: "Provides an OpenSearch Dashboards object resource. This resource interacts directly with the underlying OpenSearch index backing Dashboards, so the format must match what Dashboards the version of Dashboards is expecting. Dashboards with older versions - directly pulling the JSON from a Dashboards index of the same version of OpenSearch targeted by the provider is a workaround. For index patterns, per-field popularity counters (`fields[].count`) are ignored when diffing: Dashboards increments them as people use fields in Discover, so they are usage telemetry rather than configuration.",
+		Description: "Provides an OpenSearch Dashboards object resource. This resource interacts directly with the underlying OpenSearch index backing Dashboards, so the format must match what Dashboards the version of Dashboards is expecting. Dashboards with older versions - directly pulling the JSON from a Dashboards index of the same version of OpenSearch targeted by the provider is a workaround. Bookkeeping Dashboards maintains itself is ignored when diffing: `updated_at`, which the saved objects API restamps on every write, and an index pattern's per-field popularity counters (`fields[].count`), which Dashboards increments as people use fields in Discover.",
 		Create:      resourceOpensearchDashboardObjectCreate,
 		Read:        resourceOpensearchDashboardObjectRead,
 		Update:      resourceOpensearchDashboardObjectUpdate,
@@ -82,7 +82,7 @@ func resourceOpensearchDashboardObject() *schema.Resource {
 				StateFunc: func(v interface{}) string {
 					return normalizeDashboardObjectForState(v)
 				},
-				DiffSuppressFunc: dashboardObjectPopularityDiffSuppress,
+				DiffSuppressFunc: dashboardObjectBookkeepingDiffSuppress,
 				Description:      "The JSON body of the dashboard object.",
 			},
 			"tenant_name": {
@@ -105,27 +105,31 @@ func resourceOpensearchDashboardObject() *schema.Resource {
 	}
 }
 
-// Dashboards increments an index pattern's per-field popularity counter every time someone
-// uses that field in Discover, writing it back into the saved object. It is usage telemetry
-// rather than configuration, so a difference confined to those counters is not drift worth
-// reporting: reverting them would only churn the document and they would climb again.
-func dashboardObjectPopularityDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	oldStripped, err := stripDashboardFieldPopularity(old)
+// Dashboards maintains bookkeeping of its own inside a saved object: it restamps
+// `updated_at` whenever the saved objects API writes the document, and it increments an index
+// pattern's per-field popularity counter every time someone uses that field in Discover. Both
+// are records of use rather than configuration, and using Dashboards is enough to change them,
+// so a difference confined to them is not drift worth reporting — reverting it would only churn
+// the document and it would come back. Any difference in real content still diffs in full.
+func dashboardObjectBookkeepingDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	oldStripped, err := stripDashboardBookkeeping(old)
 	if err != nil {
 		return false
 	}
-	newStripped, err := stripDashboardFieldPopularity(new)
+	newStripped, err := stripDashboardBookkeeping(new)
 	if err != nil {
 		return false
 	}
 	return oldStripped == newStripped
 }
 
-// stripDashboardFieldPopularity returns body with every index pattern's `count` field removed,
-// canonicalised so two bodies differing only in those counters compare equal. Anything that
-// does not parse as the expected shape is left untouched rather than dropped, so an unexpected
-// document still diffs on its real contents.
-func stripDashboardFieldPopularity(body string) (string, error) {
+// stripDashboardBookkeeping returns body without the parts of a saved object that Dashboards
+// maintains on its own — `_source.updated_at`, and each index pattern's `fields[].count` —
+// canonicalised so two bodies differing only in those compare equal. `migrationVersion` is
+// deliberately kept: it records the shape of the stored document, so a change there is real.
+// Anything that does not parse as the expected shape is left untouched rather than dropped, so
+// an unexpected document still diffs on its real contents.
+func stripDashboardBookkeeping(body string) (string, error) {
 	var objects []interface{}
 	if err := json.Unmarshal([]byte(body), &objects); err != nil {
 		return "", err
@@ -140,6 +144,8 @@ func stripDashboardFieldPopularity(body string) (string, error) {
 		if !ok {
 			continue
 		}
+		delete(source, "updated_at")
+
 		objectType, ok := source["type"].(string)
 		if !ok || objectType != "index-pattern" {
 			continue

--- a/provider/resource_opensearch_dashboard_object.go
+++ b/provider/resource_opensearch_dashboard_object.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -24,6 +25,9 @@ func resourceOpensearchDashboardObject() *schema.Resource {
 		Read:        resourceOpensearchDashboardObjectRead,
 		Update:      resourceOpensearchDashboardObjectUpdate,
 		Delete:      resourceOpensearchDashboardObjectDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceOpensearchDashboardObjectImport,
+		},
 		CustomizeDiff: customdiff.ForceNewIfChange(
 			"body",
 			// force recreation if _id of object changed
@@ -98,6 +102,40 @@ func resourceOpensearchDashboardObject() *schema.Resource {
 			},
 		},
 	}
+}
+
+func resourceOpensearchDashboardObjectImport(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	objectID, tenantName, indexName, err := parseDashboardObjectImportID(d.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	if tenantName != "" {
+		if err := d.Set("tenant_name", tenantName); err != nil {
+			return nil, err
+		}
+	}
+	if indexName != "" {
+		if err := d.Set("index", indexName); err != nil {
+			return nil, err
+		}
+	}
+
+	d.SetId(objectID)
+
+	seedBodyBytes, err := json.Marshal([]map[string]interface{}{{
+		"_id":     objectID,
+		"_source": map[string]interface{}{},
+	}})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := d.Set("body", string(seedBodyBytes)); err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func resourceOpensearchDashboardObjectCreate(d *schema.ResourceData, meta interface{}) error {
@@ -306,7 +344,13 @@ type dashboardObjectState struct {
 func readDashboardObjectState(d *schema.ResourceData) (*dashboardObjectState, error) {
 	dashboardObject, err := readBodyInterface(d.Get("body"))
 	if err != nil {
-		return nil, fmt.Errorf("could not read body interface: %+v", err)
+		if d.Id() == "" {
+			return nil, fmt.Errorf("could not read body interface: %+v", err)
+		}
+		dashboardObject = map[string]interface{}{
+			"_id":     d.Id(),
+			"_source": map[string]interface{}{},
+		}
 	}
 	// Calculate index if tenantName is given
 	indexName := d.Get("index").(string)
@@ -321,12 +365,80 @@ func readDashboardObjectState(d *schema.ResourceData) (*dashboardObjectState, er
 	if indexName == "" {
 		indexName = ".kibana"
 	}
+
+	objectID, ok := dashboardObject["_id"].(string)
+	if !ok || objectID == "" {
+		if d.Id() == "" {
+			return nil, fmt.Errorf("dashboard object body missing valid _id")
+		}
+		objectID = d.Id()
+		dashboardObject["_id"] = objectID
+	}
+
+	if dashboardObject["_source"] == nil {
+		dashboardObject["_source"] = map[string]interface{}{}
+	}
+
 	return &dashboardObjectState{
 		index:           indexName,
 		tenantName:      tenantName,
 		dashboardObject: dashboardObject,
-		id:              dashboardObject["_id"].(string),
+		id:              objectID,
 	}, nil
+}
+
+func parseDashboardObjectImportID(input string) (string, string, string, error) {
+	if input == "" {
+		return "", "", "", fmt.Errorf("invalid import ID: expected object_id[,tenant_name=<name>][,index=<name>]")
+	}
+
+	parts := strings.Split(input, ",")
+	objectID := strings.TrimSpace(parts[0])
+	if objectID == "" {
+		return "", "", "", fmt.Errorf("invalid import ID %q: object_id cannot be empty", input)
+	}
+
+	tenantName := ""
+	indexName := ""
+
+	for _, raw := range parts[1:] {
+		part := strings.TrimSpace(raw)
+		if part == "" {
+			continue
+		}
+
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) != 2 {
+			return "", "", "", fmt.Errorf("invalid import ID %q: expected key=value segment %q", input, part)
+		}
+
+		key := strings.TrimSpace(kv[0])
+		value := strings.TrimSpace(kv[1])
+		if value == "" {
+			return "", "", "", fmt.Errorf("invalid import ID %q: value for %q cannot be empty", input, key)
+		}
+
+		switch key {
+		case "tenant_name":
+			if tenantName != "" {
+				return "", "", "", fmt.Errorf("invalid import ID %q: tenant_name provided more than once", input)
+			}
+			tenantName = value
+		case "index":
+			if indexName != "" {
+				return "", "", "", fmt.Errorf("invalid import ID %q: index provided more than once", input)
+			}
+			indexName = value
+		default:
+			return "", "", "", fmt.Errorf("invalid import ID %q: unsupported key %q", input, key)
+		}
+	}
+
+	if tenantName != "" && indexName != "" {
+		return "", "", "", fmt.Errorf("invalid import ID %q: tenant_name conflicts with index", input)
+	}
+
+	return objectID, tenantName, indexName, nil
 }
 
 func readBodyInterface(i interface{}) (map[string]interface{}, error) {

--- a/provider/resource_opensearch_dashboard_object_test.go
+++ b/provider/resource_opensearch_dashboard_object_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 	"testing"
 
 	elastic7 "github.com/olivere/elastic/v7"
@@ -429,3 +430,87 @@ resource "opensearch_dashboard_object" "test_invalid" {
 EOF
 }
 `
+
+func indexPatternBody(fields string) string {
+	return `[{"_id":"index-pattern:logs","_source":{"type":"index-pattern","index-pattern":{"title":"logs-*","timeFieldName":"@timestamp","fields":"` + fields + `"},"references":[]}}]`
+}
+
+func TestDashboardObjectPopularityDiffSuppress(t *testing.T) {
+	// Popularity counters live inside the JSON-encoded `fields` attribute, so the escaping
+	// here is what an export actually contains.
+	noPopularity := `[{\"count\":0,\"name\":\"@timestamp\",\"type\":\"date\"},{\"count\":0,\"name\":\"message\",\"type\":\"string\"}]`
+	somePopularity := `[{\"count\":7,\"name\":\"@timestamp\",\"type\":\"date\"},{\"count\":3,\"name\":\"message\",\"type\":\"string\"}]`
+	renamedField := `[{\"count\":0,\"name\":\"@timestamp\",\"type\":\"date\"},{\"count\":0,\"name\":\"msg\",\"type\":\"string\"}]`
+
+	visualization := `[{"_id":"visualization:errors","_source":{"type":"visualization","visualization":{"title":"Errors","visState":"{\"aggs\":[{\"type\":\"count\"}]}"},"references":[]}}]`
+	visualizationAvg := `[{"_id":"visualization:errors","_source":{"type":"visualization","visualization":{"title":"Errors","visState":"{\"aggs\":[{\"type\":\"avg\"}]}"},"references":[]}}]`
+
+	testCases := []struct {
+		name     string
+		old      string
+		new      string
+		suppress bool
+	}{
+		{
+			name:     "popularity climbed since export",
+			old:      indexPatternBody(somePopularity),
+			new:      indexPatternBody(noPopularity),
+			suppress: true,
+		},
+		{
+			name:     "identical bodies",
+			old:      indexPatternBody(somePopularity),
+			new:      indexPatternBody(somePopularity),
+			suppress: true,
+		},
+		{
+			name:     "field renamed as well as popularity",
+			old:      indexPatternBody(somePopularity),
+			new:      indexPatternBody(renamedField),
+			suppress: false,
+		},
+		{
+			name:     "title changed",
+			old:      indexPatternBody(somePopularity),
+			new:      strings.Replace(indexPatternBody(noPopularity), "logs-*", "logs-2024-*", 1),
+			suppress: false,
+		},
+		{
+			name: "count in a non index-pattern object is left alone",
+			// `count` here is an aggregation type, not a popularity counter.
+			old:      visualization,
+			new:      visualizationAvg,
+			suppress: false,
+		},
+		{
+			name:     "unparseable body is not suppressed",
+			old:      "not json",
+			new:      indexPatternBody(noPopularity),
+			suppress: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := dashboardObjectPopularityDiffSuppress("body", tc.old, tc.new, nil); got != tc.suppress {
+				t.Fatalf("expected suppress %v, got %v", tc.suppress, got)
+			}
+		})
+	}
+}
+
+func TestStripDashboardFieldPopularity(t *testing.T) {
+	stripped, err := stripDashboardFieldPopularity(indexPatternBody(`[{\"count\":7,\"name\":\"@timestamp\"}]`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(stripped, "count") {
+		t.Fatalf("expected popularity counter to be removed, got %s", stripped)
+	}
+	// Everything else about the object has to survive, or unrelated drift would be hidden too.
+	for _, want := range []string{"index-pattern:logs", "logs-*", "@timestamp", "timeFieldName"} {
+		if !strings.Contains(stripped, want) {
+			t.Fatalf("expected %q to survive stripping, got %s", want, stripped)
+		}
+	}
+}

--- a/provider/resource_opensearch_dashboard_object_test.go
+++ b/provider/resource_opensearch_dashboard_object_test.go
@@ -13,6 +13,75 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+func TestParseDashboardObjectImportID(t *testing.T) {
+	testCases := []struct {
+		name       string
+		input      string
+		objectID   string
+		tenantName string
+		indexName  string
+		expectErr  bool
+	}{
+		{
+			name:      "default",
+			input:     "response-time-percentile",
+			objectID:  "response-time-percentile",
+			indexName: "",
+		},
+		{
+			name:       "tenant name",
+			input:      "response-time-percentile,tenant_name=tenant_test",
+			objectID:   "response-time-percentile",
+			tenantName: "tenant_test",
+		},
+		{
+			name:      "custom index",
+			input:     "response-time-percentile,index=.kibana_custom",
+			objectID:  "response-time-percentile",
+			indexName: ".kibana_custom",
+		},
+		{
+			name:      "empty object id",
+			input:     ",tenant_name=tenant_test",
+			expectErr: true,
+		},
+		{
+			name:      "unknown key",
+			input:     "response-time-percentile,foo=bar",
+			expectErr: true,
+		},
+		{
+			name:      "conflicting keys",
+			input:     "response-time-percentile,tenant_name=tenant_test,index=.kibana_custom",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			objectID, tenantName, indexName, err := parseDashboardObjectImportID(tc.input)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if objectID != tc.objectID {
+				t.Fatalf("expected object_id %q, got %q", tc.objectID, objectID)
+			}
+			if tenantName != tc.tenantName {
+				t.Fatalf("expected tenant_name %q, got %q", tc.tenantName, tenantName)
+			}
+			if indexName != tc.indexName {
+				t.Fatalf("expected index %q, got %q", tc.indexName, indexName)
+			}
+		})
+	}
+}
+
 func TestAccOpensearchDashboardObject(t *testing.T) {
 	provider := Provider()
 	diags := provider.Configure(context.Background(), &terraform.ResourceConfig{})
@@ -32,6 +101,12 @@ func TestAccOpensearchDashboardObject(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckOpensearchDashboardObjectExists("opensearch_dashboard_object.test_visualization", "response-time-percentile", ""),
 				),
+			},
+			{
+				ResourceName:      "opensearch_dashboard_object.test_visualization",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "response-time-percentile",
 			},
 			{
 				Config: indexPatternConfig,
@@ -70,6 +145,12 @@ func TestAccOpensearchDashboardObjectWithTenant(t *testing.T) {
 					resource.TestCheckResourceAttr("opensearch_dashboard_tenant.tenant_test", "tenant_name", "tenant_test"),
 					testCheckOpensearchDashboardObjectExists("opensearch_dashboard_object.test_visualization", "response-time-percentile", "tenant_test"),
 				),
+			},
+			{
+				ResourceName:      "opensearch_dashboard_object.test_visualization",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "response-time-percentile,tenant_name=tenant_test",
 			},
 			{
 				Config: indexPatternConfig,

--- a/provider/resource_opensearch_dashboard_object_test.go
+++ b/provider/resource_opensearch_dashboard_object_test.go
@@ -432,10 +432,14 @@ EOF
 `
 
 func indexPatternBody(fields string) string {
-	return `[{"_id":"index-pattern:logs","_source":{"type":"index-pattern","index-pattern":{"title":"logs-*","timeFieldName":"@timestamp","fields":"` + fields + `"},"references":[]}}]`
+	return indexPatternBodyAt(fields, "2026-01-01T00:00:00.000Z")
 }
 
-func TestDashboardObjectPopularityDiffSuppress(t *testing.T) {
+func indexPatternBodyAt(fields, updatedAt string) string {
+	return `[{"_id":"index-pattern:logs","_source":{"type":"index-pattern","index-pattern":{"title":"logs-*","timeFieldName":"@timestamp","fields":"` + fields + `"},"references":[],"updated_at":"` + updatedAt + `"}}]`
+}
+
+func TestDashboardObjectBookkeepingDiffSuppress(t *testing.T) {
 	// Popularity counters live inside the JSON-encoded `fields` attribute, so the escaping
 	// here is what an export actually contains.
 	noPopularity := `[{\"count\":0,\"name\":\"@timestamp\",\"type\":\"date\"},{\"count\":0,\"name\":\"message\",\"type\":\"string\"}]`
@@ -483,6 +487,32 @@ func TestDashboardObjectPopularityDiffSuppress(t *testing.T) {
 			suppress: false,
 		},
 		{
+			// What Dashboards actually does: bumping a counter restamps updated_at too.
+			name:     "popularity climbed and updated_at was restamped",
+			old:      indexPatternBodyAt(somePopularity, "2026-08-17T21:04:11.884Z"),
+			new:      indexPatternBodyAt(noPopularity, "2026-01-01T00:00:00.000Z"),
+			suppress: true,
+		},
+		{
+			name:     "updated_at alone",
+			old:      indexPatternBodyAt(somePopularity, "2026-08-17T21:04:11.884Z"),
+			new:      indexPatternBodyAt(somePopularity, "2026-01-01T00:00:00.000Z"),
+			suppress: true,
+		},
+		{
+			name:     "updated_at restamped alongside a real edit",
+			old:      indexPatternBodyAt(somePopularity, "2026-08-17T21:04:11.884Z"),
+			new:      strings.Replace(indexPatternBodyAt(noPopularity, "2026-01-01T00:00:00.000Z"), "logs-*", "logs-2024-*", 1),
+			suppress: false,
+		},
+		{
+			// migrationVersion is real content, so it must still diff.
+			name:     "migrationVersion changed",
+			old:      strings.Replace(indexPatternBody(somePopularity), `"references":[]`, `"references":[],"migrationVersion":{"index-pattern":"7.6.0"}`, 1),
+			new:      strings.Replace(indexPatternBody(noPopularity), `"references":[]`, `"references":[],"migrationVersion":{"index-pattern":"7.11.0"}`, 1),
+			suppress: false,
+		},
+		{
 			name:     "unparseable body is not suppressed",
 			old:      "not json",
 			new:      indexPatternBody(noPopularity),
@@ -492,20 +522,22 @@ func TestDashboardObjectPopularityDiffSuppress(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := dashboardObjectPopularityDiffSuppress("body", tc.old, tc.new, nil); got != tc.suppress {
+			if got := dashboardObjectBookkeepingDiffSuppress("body", tc.old, tc.new, nil); got != tc.suppress {
 				t.Fatalf("expected suppress %v, got %v", tc.suppress, got)
 			}
 		})
 	}
 }
 
-func TestStripDashboardFieldPopularity(t *testing.T) {
-	stripped, err := stripDashboardFieldPopularity(indexPatternBody(`[{\"count\":7,\"name\":\"@timestamp\"}]`))
+func TestStripDashboardBookkeeping(t *testing.T) {
+	stripped, err := stripDashboardBookkeeping(indexPatternBody(`[{\"count\":7,\"name\":\"@timestamp\"}]`))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if strings.Contains(stripped, "count") {
-		t.Fatalf("expected popularity counter to be removed, got %s", stripped)
+	for _, unwanted := range []string{"count", "updated_at"} {
+		if strings.Contains(stripped, unwanted) {
+			t.Fatalf("expected %q to be removed, got %s", unwanted, stripped)
+		}
 	}
 	// Everything else about the object has to survive, or unrelated drift would be hidden too.
 	for _, want := range []string{"index-pattern:logs", "logs-*", "@timestamp", "timeFieldName"} {

--- a/provider/resource_opensearch_dashboard_tenant_test.go
+++ b/provider/resource_opensearch_dashboard_tenant_test.go
@@ -67,10 +67,12 @@ func testAccCheckOpensearchDashboardTenantDestroy(s *terraform.State) error {
 			continue
 		}
 
-		meta := testAccOpendistroProvider.Meta()
+		providerConf, err := getDashboardTenantTestProviderConf()
+		if err != nil {
+			return err
+		}
 
-		var err error
-		_, err = resourceOpensearchGetOpenDistroDashboardTenant(rs.Primary.ID, meta.(*ProviderConf))
+		_, err = resourceOpensearchGetOpenDistroDashboardTenant(rs.Primary.ID, providerConf)
 
 		if err != nil {
 			return nil // should be not found error
@@ -88,10 +90,12 @@ func testCheckOpensearchDashboardTenantExists(name string) resource.TestCheckFun
 				continue
 			}
 
-			meta := testAccOpendistroProvider.Meta()
+			providerConf, err := getDashboardTenantTestProviderConf()
+			if err != nil {
+				return err
+			}
 
-			var err error
-			_, err = resourceOpensearchGetOpenDistroDashboardTenant(rs.Primary.ID, meta.(*ProviderConf))
+			_, err = resourceOpensearchGetOpenDistroDashboardTenant(rs.Primary.ID, providerConf)
 
 			if err != nil {
 				return err
@@ -102,6 +106,22 @@ func testCheckOpensearchDashboardTenantExists(name string) resource.TestCheckFun
 
 		return nil
 	}
+}
+
+func getDashboardTenantTestProviderConf() (*ProviderConf, error) {
+	if testAccOpendistroProvider != nil {
+		if meta, ok := testAccOpendistroProvider.Meta().(*ProviderConf); ok && meta != nil {
+			return meta, nil
+		}
+	}
+
+	if testAccProvider != nil {
+		if meta, ok := testAccProvider.Meta().(*ProviderConf); ok && meta != nil {
+			return meta, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no configured provider metadata available for dashboard tenant test helpers")
 }
 
 func testAccOpenDistroDashboardTenantResource(resourceName string) string {


### PR DESCRIPTION
### Description
This adds import support to dashboard objects, including tenant-scoped and custom-index imports, with tests and docs.

### Tests:
- parser unit tests and acceptance import steps:
  - resource_opensearch_dashboard_object_test.go:16
- tenant helper hardening to prevent nil meta panic:
  - resource_opensearch_dashboard_tenant_test.go:111
- Verified successful import with AWS OpenSearch Instance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
