### PR TITLE
Skip client healthcheck for OpenSearch Serverless

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -503,7 +503,12 @@ func getClient(conf *ProviderConf) (*elastic7.Client, error) {
 			return nil, err
 		}
 		client.Transport = Wrap(client.Transport)
-		opts = append(opts, elastic7.SetHttpClient(client), elastic7.SetSniff(false))
+		// Serverless serves no operation on the root path, so the client's
+		// startup healthcheck, a HEAD request to it, always fails and is not a
+		// signal that the collection is unreachable. Disable it for the same
+		// reason sniffing is disabled: Serverless supports neither.
+		// https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-genref.html
+		opts = append(opts, elastic7.SetHttpClient(client), elastic7.SetSniff(false), elastic7.SetHealthcheck(false))
 		conf.flavor = OpenSearch
 		if conf.osVersion == "" {
 			conf.osVersion = minimalOpensearchServerlessVersion

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -90,6 +91,56 @@ func TestInvalidCredentials(t *testing.T) {
 	errString := "HTTP 401 Unauthorized: Please ensure that the correct credentials are being used to access the cluster"
 	if err.Error() != errString {
 		t.Errorf("Error thrown should be %s", errString)
+	}
+}
+
+// Given:
+// 1. an OpenSearch Serverless collection, which serves no operation on the root path
+// 2. healthchecking enabled, as it is by default
+//
+// this tests that getClient skips the client's startup healthcheck, a HEAD
+// request to the root path, which can never succeed against Serverless however
+// the collection's data access policy is configured
+func TestServerlessSkipsHealthcheck(t *testing.T) {
+	var rootPathCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "" || r.URL.Path == "/" {
+			// Serverless has no handler for the root path
+			rootPathCalls.Add(1)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	parsedUrl, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Failed parsing test server url: %v", err)
+	}
+
+	// An aoss signature service with a region selects the Serverless code path
+	// for endpoints outside of *.aoss.amazonaws.com, and static credentials keep
+	// the test off the ambient credential chain.
+	testConfig := &ProviderConf{
+		rawUrl:             server.URL,
+		parsedUrl:          parsedUrl,
+		awsSig4Service:     "aoss",
+		awsRegion:          "us-east-1",
+		signAWSRequests:    true,
+		awsAccessKeyId:     "ACCESS_KEY",
+		awsSecretAccessKey: "SECRET_KEY",
+		healthchecking:     true,
+		sniffing:           false,
+		pingTimeoutSeconds: 10,
+	}
+
+	if _, err := getClient(testConfig); err != nil {
+		t.Fatalf("getClient failed against a Serverless collection: %v", err)
+	}
+
+	if calls := rootPathCalls.Load(); calls != 0 {
+		t.Errorf("healthcheck should not have run, got %d requests to the root path", calls)
 	}
 }
 


### PR DESCRIPTION
### Description

OpenSearch Serverless serves no operation on the root path, so the client's startup healthcheck, a HEAD request to it, can never succeed against a collection endpoint. The provider already disables sniffing on the Serverless branch for the same reason, and pins a minimal version to skip the version ping, but left the healthcheck enabled, so a collection with default provider settings always failed to connect.

Disable the healthcheck on that branch too, and add a regression test that stands up a server returning 404 on the root path.

### Issues Resolved

Fixes #234


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
