### PR TITLE
fix(ism-policy): detect 404 on read so create fires

### DIFF
--- a/provider/resource_opensearch_ism_policy.go
+++ b/provider/resource_opensearch_ism_policy.go
@@ -173,7 +173,11 @@ func resourceOpensearchGetISMPolicy(policyID string, m interface{}) (GetPolicyRe
 	})
 
 	if err != nil {
-		return *response, fmt.Errorf("error getting policy: %+v : %+v", path, err)
+		// Return the raw err so its *elastic.Error type survives. Read gates
+		// create on IsNotFound, which type-switches on the concrete error and
+		// never unwraps, so a wrapped 404 would be missed and create never fires.
+		log.Printf("[INFO] error getting policy at %s: %+v", path, err)
+		return *response, err
 	}
 	body = &res.Body
 


### PR DESCRIPTION
### Description

`opensearch_ism_policy` fails to create a policy that doesn't yet exist, erroring with "error getting policy: ... 404 (Not Found): Policy not found".

`resourceOpensearchGetISMPolicy` wraps its GET error, so `resourceOpensearchISMPolicyRead`'s `elastic7.IsNotFound(err)` check no longer sees the 404 (IsStatusCode type-switches on the concrete error and never unwraps). Create is gated on that check, so it never runs.

Fix: return the raw error, matching composable_index_template and component_template, which are unaffected for exactly this reason.

### Issues Resolved

Part of #121.

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.