### PR TITLE
fix(ism-policy): re-read seq_no before put to avoid 409

### DIFF
--- a/provider/resource_opensearch_ism_policy.go
+++ b/provider/resource_opensearch_ism_policy.go
@@ -197,6 +197,17 @@ func resourceOpensearchPutISMPolicy(d *schema.ResourceData, m interface{}) (*Put
 	primTerm := d.Get("primary_term").(int)
 	params := url.Values{}
 
+	// Re-read live seq_no/primary_term right before PUT. State value lags
+	// (ISM writes own policy metadata after create/read); 409 retrier below
+	// replays stale value, never converges. Guard on current version fixes it.
+	if seq >= 0 && primTerm > 0 {
+		// Re-read failed: fall back to state value (original behavior).
+		if cur, gerr := resourceOpensearchGetISMPolicy(d.Get("policy_id").(string), m); gerr == nil {
+			seq = cur.SeqNo
+			primTerm = cur.PrimaryTerm
+		}
+	}
+
 	if seq >= 0 && primTerm > 0 {
 		params.Set("if_seq_no", strconv.Itoa(seq))
 		params.Set("if_primary_term", strconv.Itoa(primTerm))


### PR DESCRIPTION
### Description

Updates fail with a version conflict:

```
Error 409 (Conflict): required seqNo [N] ... current document has seqNo [N+1]
```

`resourceOpensearchPutISMPolicy` sends seq_no/primary_term from state as if_seq_no/if_primary_term. ISM bumps the doc's seq_no with its own metadata after create, so the state value is stale and the PUT 409s. The 409 retrier replays the same stale value, so it never converges.

Fix: re-read the live seq_no/primary_term before the PUT, keeping the optimistic-concurrency guard rather than dropping it.

### Issues Resolved

Part of #121.

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.