### PR TITLE
fix: skip env-sourced web identity when static credentials exist

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -343,6 +343,15 @@ func providerConfigure(c context.Context, d *schema.ResourceData) (interface{}, 
 // an explicit aws_profile wins over ambient IRSA env vars. Web identity set
 // explicitly in the provider config is left untouched and still applies.
 //
+// Static credentials — whether from the provider config (aws_access_key) or
+// from the environment (AWS_ACCESS_KEY_ID) — also suppress env-sourced web
+// identity. Provider-config static creds already win unconditionally in
+// awsSession (case 1), but env-var static creds are only discovered by the
+// SDK default chain (case 5). If we populate the web identity fields here,
+// case 3 fires first and the static env creds are never reached — a priority
+// inversion that breaks EKS pods where IRSA vars coexist with CI/CD-assumed
+// role credentials (e.g. Jenkins withAWS).
+//
 // This matches botocore at commit d6092247:
 //   - create_credential_resolver derives disable_env_vars from whether a profile
 //     was explicitly selected:
@@ -352,10 +361,10 @@ func providerConfigure(c context.Context, d *schema.ResourceData) (interface{}, 
 //     when a profile was explicitly selected:
 //     https://github.com/boto/botocore/blob/d6092247/botocore/credentials.py#L1918-L1924
 func resolveAWSWebIdentityEnv(conf *ProviderConf) {
-	// An explicit profile disables env-var-sourced web identity (botocore's
-	// disable_env_vars). aws_access_key is not checked here because static keys
-	// already take unconditional precedence in awsSession.
 	if conf.awsProfile != "" {
+		return
+	}
+	if conf.awsAccessKeyId != "" || os.Getenv("AWS_ACCESS_KEY_ID") != "" {
 		return
 	}
 	if conf.awsWebIdentityRoleArn == "" {

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -516,6 +516,48 @@ func TestAWSCredsWebIdentityEnvSuppressedByProfile(t *testing.T) {
 }
 
 // Given:
+// 1. AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE are set (as EKS IRSA injects them)
+// 2. AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are also set (e.g. by a CI/CD
+//    step that assumes a cross-account role)
+//
+// This tests that: the env-sourced static credentials take precedence over
+// env-sourced web identity, matching the AWS SDK default credential chain
+// priority. Without the static-creds guard in resolveAWSWebIdentityEnv, the
+// web identity fields are populated and awsSession case 3 fires before case 5
+// (default chain) can discover the static env creds — a priority inversion
+// that causes the provider to authenticate as the IRSA pod role instead of the
+// assumed cross-account role.
+func TestAWSCredsEnvStaticCredsOverrideWebIdentityEnv(t *testing.T) {
+	envAccessKeyID := "ENV_ACCESS_KEY"
+	testRegion := "us-east-1"
+
+	os.Setenv("AWS_ACCESS_KEY_ID", envAccessKeyID)
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "ENV_SECRET")
+	os.Setenv("AWS_ROLE_ARN", "arn:aws:iam::123456789012:role/demo/TestWebIdentity")
+	os.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "./test-fixtures/web_identity_token")
+
+	testConfig := &ProviderConf{}
+	resolveAWSWebIdentityEnv(testConfig)
+
+	if testConfig.awsWebIdentityRoleArn != "" {
+		t.Errorf("expected web identity role arn to be suppressed by env static creds, got %s", testConfig.awsWebIdentityRoleArn)
+	}
+	if testConfig.awsWebIdentityTokenFile != "" {
+		t.Errorf("expected web identity token file to be suppressed by env static creds, got %s", testConfig.awsWebIdentityTokenFile)
+	}
+
+	creds := getCreds(t, testRegion, testConfig, "")
+	if creds.AccessKeyID != envAccessKeyID {
+		t.Errorf("access key id should have been %s (we got %s)", envAccessKeyID, creds.AccessKeyID)
+	}
+
+	os.Unsetenv("AWS_ACCESS_KEY_ID")
+	os.Unsetenv("AWS_SECRET_ACCESS_KEY")
+	os.Unsetenv("AWS_ROLE_ARN")
+	os.Unsetenv("AWS_WEB_IDENTITY_TOKEN_FILE")
+}
+
+// Given:
 // 1. A web identity role ARN and token file are configured
 // 2. aws_assume_role_arn is also configured
 //


### PR DESCRIPTION
### Description

`resolveAWSWebIdentityEnv()` unconditionally reads `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` from the environment. On EKS pods with IRSA, these vars are always present (injected by the pod identity webhook at the container spec level). When a CI/CD pipeline assumes a cross-account role and exports static credentials (`AWS_ACCESS_KEY_ID`, etc.), `awsSession` case 3 (web identity) fires before case 5 (default chain), causing the provider to authenticate as the IRSA pod role instead of the assumed cross-account role.

This adds a guard: if `AWS_ACCESS_KEY_ID` is set in the environment (or `aws_access_key` in the provider config), skip env-var-sourced web identity resolution. This matches the AWS SDK default credential chain priority where static env creds take precedence over web identity.

- Explicitly configured web identity (via provider args `aws_web_identity_role_arn` / `aws_web_identity_token_file`) is **unaffected** — only the env-var fallback is suppressed.
- IRSA autodiscovery still works when no static creds are present.
- Role chaining (web identity → assume role) is unaffected.

### Issues Resolved

Fixes #333

### Check List

- [x] New functionality includes testing
- [x] New functionality has been documented in the resource/provider description
- [x] Commits are signed per the DCO using `--signoff`

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).