### PR TITLE
fix: surface the underlying error on healthcheck failure and unusable cacert_file

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -418,7 +418,7 @@ func getOSClient(conf *ProviderConf) (*opensearch.Client, error) {
 
 func createOSHttpClient(conf *ProviderConf) (*http.Client, error) {
 	if !conf.signAWSRequests {
-		return createNonAWSHttpClient(conf), nil
+		return createNonAWSHttpClient(conf)
 	}
 
 	if m := awsUrlRegexp.FindStringSubmatch(conf.parsedUrl.Hostname()); m != nil {
@@ -447,23 +447,26 @@ func createOSHttpClient(conf *ProviderConf) (*http.Client, error) {
 		return awsHttpClient(conf.awsRegion, conf, map[string]string{})
 	}
 
-	return createNonAWSHttpClient(conf), nil
+	return createNonAWSHttpClient(conf)
 }
 
-func createNonAWSHttpClient(conf *ProviderConf) *http.Client {
+func createNonAWSHttpClient(conf *ProviderConf) (*http.Client, error) {
 	if conf.insecure || conf.cacertFile != "" {
-		client := tlsHttpClient(conf, map[string]string{})
-		if conf.token != "" {
-			return tokenHttpClient(conf, map[string]string{})
+		client, err := tlsHttpClient(conf, map[string]string{})
+		if err != nil {
+			return nil, err
 		}
-		return client
+		if conf.token != "" {
+			return tokenHttpClient(conf, map[string]string{}), nil
+		}
+		return client, nil
 	}
 
 	if conf.token != "" {
-		return tokenHttpClient(conf, map[string]string{})
+		return tokenHttpClient(conf, map[string]string{}), nil
 	}
 
-	return defaultHttpClient(conf, map[string]string{})
+	return defaultHttpClient(conf, map[string]string{}), nil
 }
 
 func getClient(conf *ProviderConf) (*elastic7.Client, error) {
@@ -516,7 +519,11 @@ func getClient(conf *ProviderConf) (*elastic7.Client, error) {
 		}
 		opts = append(opts, elastic7.SetHttpClient(client), elastic7.SetSniff(false))
 	} else if conf.insecure || conf.cacertFile != "" {
-		opts = append(opts, elastic7.SetHttpClient(tlsHttpClient(conf, map[string]string{})), elastic7.SetSniff(false))
+		client, err := tlsHttpClient(conf, map[string]string{})
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, elastic7.SetHttpClient(client), elastic7.SetSniff(false))
 		if conf.token != "" {
 			opts = append(opts, elastic7.SetHttpClient(tokenHttpClient(conf, map[string]string{})), elastic7.SetSniff(false))
 		}
@@ -560,8 +567,16 @@ func getClient(conf *ProviderConf) (*elastic7.Client, error) {
 	client, err := elastic7.NewClient(opts...)
 	if err != nil {
 		if errors.Is(err, elastic7.ErrNoClient) {
-			log.Printf("[INFO] couldn't create client: %T, %s, %T", err, err.Error(), errors.Unwrap(err))
-			return nil, errors.New("HEAD healthcheck failed: This is usually due to network or permission issues. The underlying error isn't accessible, please debug by disabling healthchecks")
+			// elastic7 wraps the real transport failure (TLS trust, DNS, proxy,
+			// a security plugin declining HEAD) inside ErrNoClient. Surface it
+			// rather than telling the user it is inaccessible: without it every
+			// cause produces the same text and the only way forward is to turn
+			// the healthcheck off and re-run.
+			cause := errors.Unwrap(err)
+			if cause == nil {
+				cause = err
+			}
+			return nil, fmt.Errorf("healthcheck failed: HEAD %s: %w (set healthcheck = false to skip this probe)", conf.rawUrl, cause)
 		}
 		return nil, err
 	}
@@ -771,31 +786,48 @@ func tokenHttpClient(conf *ProviderConf, headers map[string]string) *http.Client
 	return client
 }
 
-func tlsHttpClient(conf *ProviderConf, headers map[string]string) *http.Client {
+func tlsHttpClient(conf *ProviderConf, headers map[string]string) (*http.Client, error) {
 	// Configure TLS/SSL
 	tlsConfig := &tls.Config{}
 	if conf.certPemPath != "" && conf.keyPemPath != "" {
 		certPem, _, err := readPathOrContent(conf.certPemPath)
 		if err != nil {
-			log.Fatal(err)
+			return nil, fmt.Errorf("cert_pem: cannot read %q: %w", conf.certPemPath, err)
 		}
 		keyPem, _, err := readPathOrContent(conf.keyPemPath)
 		if err != nil {
-			log.Fatal(err)
+			return nil, fmt.Errorf("key_pem: cannot read %q: %w", conf.keyPemPath, err)
 		}
 		cert, err := tls.X509KeyPair([]byte(certPem), []byte(keyPem))
 		if err != nil {
-			log.Fatal(err)
+			return nil, fmt.Errorf("cert_pem/key_pem: invalid keypair: %w", err)
 		}
 		tlsConfig.Certificates = []tls.Certificate{cert}
 	}
 
-	// If a cacertFile has been specified, use that for cert validation
+	// If a cacertFile has been specified, use that for cert validation.
+	//
+	// Both failure modes here are silent unless we check for them, and both
+	// end in the same misleading "certificate signed by unknown authority":
+	// RootCAs is set to a pool that ended up empty, which trusts nothing
+	// rather than falling back to the system roots.
 	if conf.cacertFile != "" {
-		caCert, _, _ := readPathOrContent(conf.cacertFile)
+		caCert, wasPath, err := readPathOrContent(conf.cacertFile)
+		if err != nil {
+			return nil, fmt.Errorf("cacert_file: cannot read %q: %w", conf.cacertFile, err)
+		}
 
 		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM([]byte(caCert))
+		if !caCertPool.AppendCertsFromPEM([]byte(caCert)) {
+			// readPathOrContent falls back to treating its argument as inline
+			// content when the path does not exist, so a typo'd path arrives
+			// here as unparseable "PEM". Distinguish the two so the message
+			// names the actual problem.
+			if wasPath {
+				return nil, fmt.Errorf("cacert_file: no certificates found in %q; expected a PEM-encoded CA bundle", conf.cacertFile)
+			}
+			return nil, fmt.Errorf("cacert_file: %q is neither a readable file nor a PEM-encoded CA bundle", conf.cacertFile)
+		}
 		tlsConfig.RootCAs = caCertPool
 	}
 
@@ -821,7 +853,7 @@ func tlsHttpClient(conf *ProviderConf, headers map[string]string) *http.Client {
 
 	client := &http.Client{Transport: rt}
 
-	return client
+	return client, nil
 }
 
 func defaultHttpClient(conf *ProviderConf, headers map[string]string) *http.Client {

--- a/provider/tls_config_test.go
+++ b/provider/tls_config_test.go
@@ -1,0 +1,143 @@
+package provider
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// selfSignedCAPEM returns a PEM-encoded self-signed CA certificate, so the
+// happy path can be asserted without checking in a fixture that will expire.
+func selfSignedCAPEM(t *testing.T) []byte {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("creating certificate: %v", err)
+	}
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// A cacert_file that cannot be turned into a usable CA pool must fail loudly.
+// Previously the read error and the AppendCertsFromPEM result were both
+// discarded, leaving RootCAs set to an empty pool -- which trusts nothing and
+// surfaces much later as "certificate signed by unknown authority".
+func TestTLSHttpClientCacertFileErrors(t *testing.T) {
+	dir := t.TempDir()
+
+	unreadable := filepath.Join(dir, "notpem.crt")
+	if err := os.WriteFile(unreadable, []byte("this is not a certificate"), 0o600); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		cacertFile string
+		wantSubstr []string
+	}{
+		{
+			name:       "directory instead of file",
+			cacertFile: dir,
+			wantSubstr: []string{"cacert_file", dir},
+		},
+		{
+			name:       "path that does not exist",
+			cacertFile: filepath.Join(dir, "missing", "ca.pem"),
+			wantSubstr: []string{"cacert_file", "neither a readable file nor a PEM-encoded CA bundle"},
+		},
+		{
+			name:       "file that is not PEM",
+			cacertFile: unreadable,
+			wantSubstr: []string{"cacert_file", "no certificates found", unreadable},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := &ProviderConf{cacertFile: tt.cacertFile}
+
+			client, err := tlsHttpClient(conf, map[string]string{})
+			if err == nil {
+				t.Fatalf("expected an error for cacert_file %q, got client %v", tt.cacertFile, client)
+			}
+			for _, want := range tt.wantSubstr {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q does not mention %q", err.Error(), want)
+				}
+			}
+		})
+	}
+}
+
+func TestTLSHttpClientCacertFileValid(t *testing.T) {
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "ca.pem")
+	if err := os.WriteFile(caPath, selfSignedCAPEM(t), 0o600); err != nil {
+		t.Fatalf("writing CA: %v", err)
+	}
+
+	conf := &ProviderConf{cacertFile: caPath}
+
+	client, err := tlsHttpClient(conf, map[string]string{})
+	if err != nil {
+		t.Fatalf("unexpected error for a valid CA bundle: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected a client")
+	}
+}
+
+// Inline PEM content (rather than a path) is a supported way to pass
+// cacert_file, and must keep working.
+func TestTLSHttpClientCacertInlineContent(t *testing.T) {
+	conf := &ProviderConf{cacertFile: string(selfSignedCAPEM(t))}
+
+	if _, err := tlsHttpClient(conf, map[string]string{}); err != nil {
+		t.Fatalf("unexpected error for inline PEM content: %v", err)
+	}
+}
+
+// The failure has to reach the caller, not just tlsHttpClient: getClient takes
+// the TLS branch whenever cacert_file is set, and used to discard the result.
+func TestGetClientSurfacesCacertError(t *testing.T) {
+	conf := &ProviderConf{
+		rawUrl:     "https://localhost:9200",
+		cacertFile: t.TempDir(), // a directory
+	}
+	parsed, err := url.Parse(conf.rawUrl)
+	if err != nil {
+		t.Fatalf("parsing url: %v", err)
+	}
+	conf.parsedUrl = parsed
+
+	if _, err := getClient(conf); err == nil {
+		t.Fatal("expected getClient to fail on an unusable cacert_file")
+	} else if !strings.Contains(err.Error(), "cacert_file") {
+		t.Errorf("error %q does not mention cacert_file", err.Error())
+	}
+}


### PR DESCRIPTION
### Description

Two places in `provider/provider.go` threw away the diagnostic that explains the failure. They're independent, but they compound — an unusable `cacert_file` is one of the most common *causes* of the healthcheck error, so you get an uninformative message and then can't find the reason for it either.

#### 1. Healthcheck

`elastic7.NewClient` wraps the real transport failure inside `ErrNoClient`. It was logged at INFO and then dropped:

```go
log.Printf("[INFO] couldn't create client: %T, %s, %T", err, err.Error(), errors.Unwrap(err))
return nil, errors.New("HEAD healthcheck failed: ... The underlying error isn't accessible, please debug by disabling healthchecks")
```

So a TLS trust problem, a DNS failure, a proxy and a security plugin declining `HEAD` all produced identical text, and the only way forward was to set `healthcheck = false`, re-run, and read the error the first attempt already had in hand. That inverts the point of the probe: it fails early with an unclear message, and the workaround is to permanently disable it.

Now:

```
healthcheck failed: HEAD https://opensearch.internal:9200: <underlying error> (set healthcheck = false to skip this probe)
```

The `errors.Unwrap` was already being called for the log line — this just puts the value where the user can see it. The hint about disabling the probe is kept; it's no longer the only content. This also makes the branch consistent with the 401/403/timeout handling immediately below it, which already produces good messages.

#### 2. `cacert_file`

```go
caCert, _, _ := readPathOrContent(conf.cacertFile)
caCertPool := x509.NewCertPool()
caCertPool.AppendCertsFromPEM([]byte(caCert))
tlsConfig.RootCAs = caCertPool
```

Both the read error and the `AppendCertsFromPEM` result were discarded. A directory, an unreadable file, or a typo'd path all ended with `RootCAs` set to a pool that had nothing in it — and a non-nil empty pool **trusts nothing** rather than falling back to the system roots. The failure surfaced much later as `x509: certificate signed by unknown authority`, which reads as "your certificate is untrusted" rather than "I never read your CA file".

Both now fail immediately, naming the configured path. The two cases get distinct messages because `readPathOrContent` treats a non-existent path as *inline content*, so a typo arrives at `AppendCertsFromPEM` as unparseable "PEM" rather than as a read error:

```
cacert_file: no certificates found in "/etc/ssl/certs/ca.pem"; expected a PEM-encoded CA bundle
cacert_file: "/etc/ssl/cert" is neither a readable file nor a PEM-encoded CA bundle
```

Passing PEM content inline still works and is covered by a test.

### Scope note

`tlsHttpClient` had to gain an `error` return to report any of this. While changing the signature I also replaced the three `log.Fatal(err)` calls in it (`cert_pem`, `key_pem`, keypair parsing) with returned errors — `log.Fatal` kills the plugin process and gives Terraform no usable diagnostic, which is the same class of problem. `createNonAWSHttpClient` propagates accordingly. Happy to split that out if you'd rather review it separately, but it seemed wrong to leave `log.Fatal` in a function I was already making error-returning.

### Testing

- 6 new unit tests in `provider/tls_config_test.go`, none requiring a cluster: `cacert_file` as a directory, as a missing path, and as a non-PEM file; the valid-CA and inline-PEM happy paths; and one asserting the error actually reaches the caller through `getClient`. The CA fixture is generated in-test, so nothing expires.
- `golangci-lint run --verbose --timeout=10m` at **v2.12** (the version pinned in `.github/workflows/test.yml`): **0 issues**. `gofmt` clean, `go vet` clean.
- `go test ./provider/` shows one failure, `TestInvalidCredentials`, which fails identically on unmodified `upstream/main` — it needs AWS STS and is unrelated to this change.

I did not change the probe from `HEAD` to `GET`. It's worth considering separately (a security plugin that blocks unauthenticated `HEAD` will still answer `GET` with a 401, which proves reachability), but it's a behaviour change rather than a bug fix and the error-wrapping stands on its own.

### Issues Resolved

Closes #337

Note for sequencing: #327 touches this same block, so whichever lands second will need a small rebase.

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using `--signoff`
- [x] No linter warnings (`golangci-lint` v2.12, as CI pins)
